### PR TITLE
[FEAT] 주문 로직에 환불 추가(구현 X), 지정가만 가격 체크

### DIFF
--- a/src/main/java/com/kanghwang/khholdings/domain/order/OrderController.java
+++ b/src/main/java/com/kanghwang/khholdings/domain/order/OrderController.java
@@ -1,11 +1,17 @@
 package com.kanghwang.khholdings.domain.order;
 
-import com.kanghwang.khholdings.domain.order.dto.OrderRequestDTO;
+import java.math.BigDecimal;
+
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.*;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
 
-import java.math.BigDecimal;
+import com.kanghwang.khholdings.domain.order.dto.OrderRequestDTO;
 
 @RestController
 @RequestMapping("/api/order")
@@ -25,8 +31,8 @@ public class OrderController {
 	}
 
 	@PostMapping
-	public ResponseEntity<String> placeOrder(@RequestBody OrderRequestDTO dto) {
-		orderService.placeOrder(dto);
+	public ResponseEntity<String> placeOrder(@RequestBody OrderRequestDTO orderDto) {
+		orderService.placeOrder(orderDto);
 		return ResponseEntity.ok("주문이 완료되었습니다.");
 	}
 }

--- a/src/main/java/com/kanghwang/khholdings/domain/order/OrderDBService.java
+++ b/src/main/java/com/kanghwang/khholdings/domain/order/OrderDBService.java
@@ -1,11 +1,12 @@
 package com.kanghwang.khholdings.domain.order;
 
-import com.kanghwang.khholdings.domain.order.dto.OrderRequestDTO;
+import java.math.BigDecimal;
+
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.math.BigDecimal;
+import com.kanghwang.khholdings.domain.order.dto.OrderRequestDTO;
 
 @Service
 public class OrderDBService {
@@ -22,7 +23,7 @@ public class OrderDBService {
 	}
 
 	@Transactional
-	public void placeOrder(long orderId, OrderRequestDTO dto) {
-		orderRepository.callPlaceOrderProcedure(orderId, dto);
+	public void placeOrder(long orderId, OrderRequestDTO orderDto) {
+		orderRepository.callPlaceOrderProcedure(orderId, orderDto);
 	}
 }

--- a/src/main/java/com/kanghwang/khholdings/domain/order/OrderRedisService.java
+++ b/src/main/java/com/kanghwang/khholdings/domain/order/OrderRedisService.java
@@ -1,12 +1,8 @@
 package com.kanghwang.khholdings.domain.order;
 
-import com.kanghwang.khholdings.domain.order.dto.OrderRequestDTO;
-import com.kanghwang.khholdings.domain.order.dto.RedisOrderDTO;
-import com.kanghwang.khholdings.domain.order.type.OrderSide;
-import com.kanghwang.khholdings.global.util.IdFormatter;
-import com.kanghwang.khholdings.global.util.RedisKeyManager;
-import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
+import java.math.BigDecimal;
+import java.util.concurrent.TimeUnit;
+
 import org.redisson.api.RLock;
 import org.redisson.api.RMap;
 import org.redisson.api.RScoredSortedSet;
@@ -14,8 +10,15 @@ import org.redisson.api.RedissonClient;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.stereotype.Service;
 
-import java.math.BigDecimal;
-import java.util.concurrent.TimeUnit;
+import com.kanghwang.khholdings.domain.order.dto.OrderRequestDTO;
+import com.kanghwang.khholdings.domain.order.dto.RedisOrderDTO;
+import com.kanghwang.khholdings.domain.order.type.OrderSide;
+import com.kanghwang.khholdings.domain.order.type.OrderType;
+import com.kanghwang.khholdings.global.util.IdFormatter;
+import com.kanghwang.khholdings.global.util.RedisKeyManager;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
 @Service
@@ -26,16 +29,16 @@ public class OrderRedisService {
 	private final OrderRepository orderRepository;
 	private final RedisTemplate<String, String> redisTemplate;
 
-	public void processOrder(String orderId, OrderRequestDTO dto) {
+	public void processOrder(String orderId, OrderRequestDTO orderDto) {
 		// 1. 특정 토큰에 대한 분산 락 획득 (동시 매칭 방지)
-		String lockKey = "lock:matching:" + dto.getTokenId();
+		String lockKey = "lock:matching:" + orderDto.getTokenId();
 		RLock lock = redissonClient.getLock(lockKey);
 
 		try {
 			// 최대 5초 대기, 10초간 잠금 점유
 			if (lock.tryLock(5, 10, TimeUnit.SECONDS)) {
 				try {
-					executeMatching(orderId, dto);
+					executeMatching(orderId, orderDto);
 				} finally {
 					lock.unlock();
 				}
@@ -46,108 +49,151 @@ public class OrderRedisService {
 		}
 	}
 
-	private void executeMatching(String orderId, OrderRequestDTO dto) {
-		OrderSide counterSide = (dto.getOrderSide() == OrderSide.BUY) ? OrderSide.SELL : OrderSide.BUY;
-		String counterBookKey = RedisKeyManager.getOrderBookKey(dto.getTokenId(), counterSide);
-		String infoKey = RedisKeyManager.getOrderInfoKey(dto.getTokenId());
+	// 매칭 엔진
+	private void executeMatching(String myOrderId, OrderRequestDTO myOrderDto) {
+		OrderSide counterSide = (myOrderDto.getOrderSide() == OrderSide.BUY) ? OrderSide.SELL : OrderSide.BUY;
+		String counterOrderBookKey = RedisKeyManager.getOrderBookKey(myOrderDto.getTokenId(), counterSide);
+		String orderInfoKey = RedisKeyManager.getOrderInfoKey(myOrderDto.getTokenId());
 
-		RScoredSortedSet<String> counterBook = redissonClient.getScoredSortedSet(counterBookKey);
-		RMap<String, RedisOrderDTO> infoMap = redissonClient.getMap(infoKey);
+		RScoredSortedSet<String> counterOrderBook = redissonClient.getScoredSortedSet(counterOrderBookKey); // 상대방의 호가창 ('가격':'주문번호')
+		RMap<String, RedisOrderDTO> infoMap = redissonClient.getMap(orderInfoKey); // 매수 및 매도 주문 상세 (가격을 포함한 모든 주문 정보)
 
-		BigDecimal myRemainingVol = dto.getOrderVolume();
-		// 내 주문이 BUY일 경우, 사용할 수 있는 총 현금(totalPrice)에서 시작
-		BigDecimal myRemainingCash = (dto.getOrderSide() == OrderSide.BUY) ? dto.getTotalPrice() : BigDecimal.ZERO;
+		BigDecimal myRemainingToken = myOrderDto.getOrderVolume(); // 미체결 수량 (매수 및 매도)
+		BigDecimal myRemainingCash = (myOrderDto.getOrderSide() == OrderSide.BUY) ? myOrderDto.getTotalPrice() : BigDecimal.ZERO; // 미체결 금액(매수 - 총 주문 금액에서 시작)
 		BigDecimal feeRate = new BigDecimal("0.0006");
 
-		while (myRemainingVol.compareTo(BigDecimal.ZERO) > 0) {
-//			String targetId = (dto.getOrderSide() == OrderSide.BUY) ? counterBook.first() : counterBook.last();
+		// 미체결 수량이 0보다 클 때 반복
+		while (myRemainingToken.compareTo(BigDecimal.ZERO) > 0) { // myRemainingToken > 0
 
-			String targetId = counterBook.first();
-			if (targetId == null) break;
+			// [Step 1] 호가창에서 첫 번째 주문을 가져옴 (=최적의 후보)
+			// 1) 매수(me) -> 가장 싼 매도 (가격을 기준으로 오름차순 정렬)
+			// 2) 매도(me) -> 가장 비싼 매수 (-가격을 기준으로 오름차순 정렬)
+			String targetOrderId = counterOrderBook.first();
+			if (targetOrderId == null) {
+				// 호가창에 주문이 없으면 break
+				break;
+			}
 
-//			Double targetPriceDouble = counterBook.getScore(targetId);
-			Double targetScore = counterBook.getScore(targetId);
-			if (targetScore == null) break;
+			// [Step 2] 지정가 주문(me)인 경우, 가격 조건 확인 (내 가격 vs 상대방 가격)
+			// 1) 매수(me) -> 내 가격 >= 상대방 가격 ("이 가격 이상으로는 안 사!")
+			// 2) 매도(me) -> 내 가격 <= 상대방 가격 ("이 가격 이하로는 안 팔아!")
+			// 호가창에서 상대방의 가격을 가져옴
+			Double targetScore = counterOrderBook.getScore(targetOrderId);
+			if (targetScore == null) {
+				// 호가창에 상대방의 가격 정보가 없으면 break
+				break;
+			}
 
+			// 상대방이 매수인 경우, 가격을 양수로 변환 (<-Sorted Set을 내림차순 정렬하기 위해 음수로 변환해서 넣음)
 			BigDecimal targetPrice = (counterSide == OrderSide.BUY)
 					? BigDecimal.valueOf(-targetScore)
 					: BigDecimal.valueOf(targetScore);
 
-			if (dto.getOrderSide() == OrderSide.BUY && dto.getOrderPrice().compareTo(targetPrice) < 0) break;
-			if (dto.getOrderSide() == OrderSide.SELL && dto.getOrderPrice().compareTo(targetPrice) > 0) break;
+			if (myOrderDto.getOrderType() == OrderType.LIMIT) {
+				if (myOrderDto.getOrderSide() == OrderSide.BUY
+					&& myOrderDto.getOrderPrice().compareTo(targetPrice) < 0) {
+					// 매수(me)인 경우, 상대방 가격이 더 비싸면 break
+					break;
+				}
+				if (myOrderDto.getOrderSide() == OrderSide.SELL
+					&& myOrderDto.getOrderPrice().compareTo(targetPrice) > 0) {
+					// 매도(me)인 경우, 상대방 가격이 더 싸면 break
+					break;
+				}
+			}
 
-			RedisOrderDTO targetOrder = infoMap.get(targetId);
+			// 주문 상세에서 상대방의 주문 정보를 가져옴
+			RedisOrderDTO targetOrder = infoMap.get(targetOrderId);
 			if (targetOrder == null) {
-				removeOrder(dto.getTokenId(), counterSide, targetId);
+				// 주문 상세에 상대방의 주문 정보가 없으면 해당 주문 제거 후, 다음 상대방 찾기 (continue)
+				removeOrder(myOrderDto.getTokenId(), counterSide, targetOrderId);
 				continue;
 			}
 
-			BigDecimal execVol = myRemainingVol.min(targetOrder.getVolume());
-			// 이번 체결에 소모되는 현금 계산
-			BigDecimal execAmount = targetPrice.multiply(execVol);
+			// [Step 3] 체결 내역 기록 및 자산 정산
+			BigDecimal executedVolume = myRemainingToken.min(targetOrder.getVolume()); // 체결할 수량 (=나와 상대방 중 더 적은 수량)
+			BigDecimal executedAmount = targetPrice.multiply(executedVolume); // 체결할 가격 = 상대방 단가(가장 유리) * 체결할 수량
 
 			long tradeId = System.currentTimeMillis();
-			long myIdLong = IdFormatter.parseOrderId(orderId);
-			long targetIdLong = IdFormatter.parseOrderId(targetId);
+			long myOrderIdLong = IdFormatter.parseOrderId(myOrderId);
+			long targetOrderIdLong = IdFormatter.parseOrderId(targetOrderId);
 
-			long buyOrderId = (dto.getOrderSide() == OrderSide.BUY) ? myIdLong : targetIdLong;
-			long sellOrderId = (dto.getOrderSide() == OrderSide.SELL) ? myIdLong : targetIdLong;
+			long buyOrderId = (myOrderDto.getOrderSide() == OrderSide.BUY) ? myOrderIdLong : targetOrderIdLong;
+			long sellOrderId = (myOrderDto.getOrderSide() == OrderSide.SELL) ? myOrderIdLong : targetOrderIdLong;
 
 			try {
 				orderRepository.p_process_transaction_hists(
-						tradeId, buyOrderId, sellOrderId, targetPrice, execVol, feeRate
+					tradeId, buyOrderId, sellOrderId, targetPrice, executedVolume, feeRate
 				);
-				log.info("Trade Executed: Price {}, Vol {}", targetPrice, execVol);
+				log.info("Trade Executed: Price {}, Volume {}, Amount {}", targetPrice, executedVolume, executedAmount);
 			} catch (Exception e) {
-				log.error("DB 정산 중 오류 발생: {}", e.getMessage());
+				log.error("체결 내역 기록 중 오류 발생: {}", e.getMessage());
 				break;
 			}
 
-			// 수량 차감 및 내 현금 잔액 갱신
-			myRemainingVol = myRemainingVol.subtract(execVol);
-			if (dto.getOrderSide() == OrderSide.BUY) {
-				myRemainingCash = myRemainingCash.subtract(execAmount);
+			// 나의 미체결 수량 및 미체결 금액(매수만) 갱신
+			myRemainingToken = myRemainingToken.subtract(executedVolume);
+			if (myOrderDto.getOrderSide() == OrderSide.BUY) {
+				myRemainingCash = myRemainingCash.subtract(executedAmount);
 			}
 
-			// 상대방 수량 차감 및 상대방이 매수자라면 현금 잔액도 갱신
-			targetOrder.setVolume(targetOrder.getVolume().subtract(execVol));
+			// 상대방 미체결 수량 및 미체결 금액(매수만) 갱신
+			targetOrder.setVolume(targetOrder.getVolume().subtract(executedVolume));
 			if (targetOrder.getSide() == OrderSide.BUY) {
-				targetOrder.setRemainingCash(targetOrder.getRemainingCash().subtract(execAmount));
+				targetOrder.setRemainingCash(targetOrder.getRemainingCash().subtract(executedAmount));
 			}
 
+			// 상대방의 미체결 수량이
+			// 1) 0보다 작거나 같으면, 해당 주문 제거
+			// 2) 0보다 크면, 주문 정보 갱신(update)
 			if (targetOrder.getVolume().compareTo(BigDecimal.ZERO) <= 0) {
-				removeOrder(dto.getTokenId(), counterSide, targetId);
+				removeOrder(myOrderDto.getTokenId(), counterSide, targetOrderId);
 			} else {
-				infoMap.put(targetId, targetOrder);
+				infoMap.put(targetOrderId, targetOrder);
 			}
 		}
 
-		// 7. 매칭 후 남은 수량이 있다면 호가창에 내 주문 등록
-		if (myRemainingVol.compareTo(BigDecimal.ZERO) > 0) {
-			String myBookKey = RedisKeyManager.getOrderBookKey(dto.getTokenId(), dto.getOrderSide());
-			RScoredSortedSet<String> myBook = redissonClient.getScoredSortedSet(myBookKey);
+		// [Step 4] 매칭 반복 후 나의 미체결 수량 처리 (시장가 vs 지정가)
+		if (myRemainingToken.compareTo(BigDecimal.ZERO) > 0) {
+			if (myOrderDto.getOrderType() == OrderType.MARKET) {
+				// 1) 시장가 주문인 경우, 미체결 수량 즉시 환불
+				// orderRepository.p_cancel_order_and_refund(
+				// 	IdFormatter.parseOrderId(myOrderId),
+				// 	myRemainingToken,
+				// 	myRemainingCash
+				// );
 
-			double score = dto.getOrderPrice().doubleValue();
-			if (dto.getOrderSide() == OrderSide.BUY) {
-				score = -score;
-			}
+				log.info("시장가 주문 잔량 환불 처리: OrderId {}, RemainingVolume {}", myOrderId, myRemainingToken);
+			} else {
+				// 2) 지정가 주문인 경우, 호가창 및 주문 상세에 등록(insert)
+				String orderBookKey = RedisKeyManager.getOrderBookKey(myOrderDto.getTokenId(),
+					myOrderDto.getOrderSide());
+				RScoredSortedSet<String> orderBook = redissonClient.getScoredSortedSet(orderBookKey);
 
-			myBook.add(score, orderId);
+				double score = myOrderDto.getOrderPrice().doubleValue(); // 내 주문 가격
+				if (myOrderDto.getOrderSide() == OrderSide.BUY) {
+					// 매수인 경우, 내림차순 정렬을 위해 가격을 음수로 변환
+					score = -score;
+				}
 
-			// RedisOrderDTO 생성자에 myRemainingCash를 추가로 넘겨줌
-			RedisOrderDTO myRedisOrder = new RedisOrderDTO(
-					orderId,
-					dto.getWalletId(),
-					dto.getTokenId(),
-					dto.getOrderPrice(),
-					myRemainingVol,
+				orderBook.add(score, myOrderId); // 해당 토큰 호가창에 내 주문 등록
+
+				// RedisOrderDTO 생성자에 myRemainingCash를 추가로 넘겨줌
+				RedisOrderDTO myRedisOrderDto = new RedisOrderDTO(
+					myOrderId,
+					myOrderDto.getWalletId(),
+					myOrderDto.getTokenId(),
+					myOrderDto.getOrderPrice(),
+					myRemainingToken,
 					myRemainingCash, // <- 이 부분이 정확히 들어가야 취소 시 돈을 돌려줄 수 있음
-					dto.getOrderSide()
-			);
-			infoMap.put(orderId, myRedisOrder);
+					myOrderDto.getOrderSide()
+				);
+				infoMap.put(myOrderId, myRedisOrderDto); // 해당 토큰 주문 상세에 내 주문 등록
+			}
 		}
 	}
 
+	// 호가창 및 주문 상세에서 주문 제거
 	public void removeOrder(Long tokenId, OrderSide side, String orderId) {
 		String bookKey = RedisKeyManager.getOrderBookKey(tokenId, side);
 		String infoKey = RedisKeyManager.getOrderInfoKey(tokenId);

--- a/src/main/java/com/kanghwang/khholdings/domain/order/OrderRepository.java
+++ b/src/main/java/com/kanghwang/khholdings/domain/order/OrderRepository.java
@@ -1,10 +1,11 @@
 package com.kanghwang.khholdings.domain.order;
 
-import com.kanghwang.khholdings.domain.order.dto.OrderRequestDTO;
+import java.math.BigDecimal;
+
 import org.apache.ibatis.annotations.Mapper;
 import org.apache.ibatis.annotations.Param;
 
-import java.math.BigDecimal;
+import com.kanghwang.khholdings.domain.order.dto.OrderRequestDTO;
 
 @Mapper
 public interface OrderRepository {
@@ -13,7 +14,7 @@ public interface OrderRepository {
 
 	BigDecimal selectAvailableBalance(Long walletId);
 
-	void callPlaceOrderProcedure(long orderId, OrderRequestDTO dto);
+	void callPlaceOrderProcedure(long orderId, OrderRequestDTO orderDto);
 
 	void p_process_transaction_hists(
 			@Param("p_trade_id") long tradeId,

--- a/src/main/java/com/kanghwang/khholdings/domain/order/OrderService.java
+++ b/src/main/java/com/kanghwang/khholdings/domain/order/OrderService.java
@@ -1,13 +1,15 @@
 package com.kanghwang.khholdings.domain.order;
 
-import com.kanghwang.khholdings.domain.order.dto.OrderRequestDTO;
-import com.kanghwang.khholdings.global.util.IdFormatter;
-import com.kanghwang.khholdings.global.util.SnowflakeIdGenerator;
-import lombok.RequiredArgsConstructor;
+import java.math.BigDecimal;
+
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.math.BigDecimal;
+import com.kanghwang.khholdings.domain.order.dto.OrderRequestDTO;
+import com.kanghwang.khholdings.global.util.IdFormatter;
+import com.kanghwang.khholdings.global.util.SnowflakeIdGenerator;
+
+import lombok.RequiredArgsConstructor;
 
 @Service
 @RequiredArgsConstructor
@@ -29,7 +31,7 @@ public class OrderService {
 
 	// 매수/매도 주문
 	@Transactional
-	public void placeOrder(OrderRequestDTO dto) {
+	public void placeOrder(OrderRequestDTO orderDto) {
 
 		// 1. Snowflake ID 생성
 		long rawId = idGenerator.nextId();
@@ -37,9 +39,9 @@ public class OrderService {
 		String preId = IdFormatter.formatOrderId(rawId);
 
 		// 2. DB에 저장하라고 넘김
-		orderDBService.placeOrder(rawId, dto);
+		orderDBService.placeOrder(rawId, orderDto);
 
 		// 3. Redis에 동일한 요청
-		orderRedisService.processOrder(preId, dto);
+		orderRedisService.processOrder(preId, orderDto);
 	}
 }


### PR DESCRIPTION
## 📌 작업 내용 요약 (Summary)
- '지정가' 주문 시에만 가격 체크하도록 수정
- '시장가' 주문 후 미체결 수량 발생 시, 호가창에 등록하지 않도록 수정 (아직 환불 프로시저는 구현 X)
- 변수명 변경, 주석 추가

## 📝 변경 사항 (Key Changes)
- [ ] OrderRedisService.java의 [Step 2]와 [Step 4] 로직
- [ ] 주문 관련 컴포넌트들 변수명 변경

## 📸 스크린샷 (Screenshots / Demos)
| Feature | Screenshot |
| :--- | :--- |
| 기능명 | 사진첨부 |

## 🔗 연관된 이슈 (Related Issues)
- Close #1

## 🧐 주요 리뷰 포인트 (Review Point)
- 환불 프로시저 구현 + 호출 + 테스트 필요!!!

## ✅ 최종 PR전 체크 리스트 (Checklist)
- [ ] 코딩 컨벤션(Checkstyle)을 준수하였는가?
- [ ] 불필요한 주석이나 시스템 로그(console.log, print)를 제거하였는가?
- [ ] 변경 사항에 대한 테스트를 완료하였는가?
- [ ] 관련 문서를 업데이트하였는가?
