### PR TITLE
[FEAT] 실시간 호가/체결 내역 불러오기 구현

### DIFF
--- a/src/main/java/com/kanghwang/khholdings/domain/market/MarketWorker.java
+++ b/src/main/java/com/kanghwang/khholdings/domain/market/MarketWorker.java
@@ -1,0 +1,48 @@
+package com.kanghwang.khholdings.domain.market;
+
+import org.redisson.api.RPatternTopic;
+import org.redisson.api.RedissonClient;
+import org.redisson.codec.JsonJacksonCodec;
+import org.springframework.messaging.simp.SimpMessagingTemplate;
+import org.springframework.stereotype.Component;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import com.kanghwang.khholdings.domain.order.dto.TransactionRequestDTO;
+
+import jakarta.annotation.PostConstruct;
+import lombok.RequiredArgsConstructor;
+
+@Component
+@RequiredArgsConstructor
+public class MarketWorker {
+
+	private final RedissonClient redissonClient;
+	private final SimpMessagingTemplate messagingTemplate;
+
+	@PostConstruct
+	public void listenTradeTopic() {
+
+		// Jackson이 OffsetDateTime을 읽을 있도록 JavaTimeModule 등록
+		ObjectMapper objectMapper = new ObjectMapper()
+			.registerModule(new JavaTimeModule()) // Java 8 날짜 타입 지원 추가
+			.disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
+
+		// 1. Redis Topic 구독 (패턴 매칭 사용: 모든 토큰의 체결을 감시)
+		// JsonJacksonCodec을 사용하여 브라우저가 읽을 수 있는 JSON 형태로 받기
+		RPatternTopic topic = redissonClient.getPatternTopic("trade:topic:*", new JsonJacksonCodec(objectMapper));
+
+		topic.addListener(TransactionRequestDTO.class, (pattern, channel, msg) -> {
+			// 2. 체결 발생 시, 채널명에서 토큰 ID 추출
+			// 채널 예: "trade:topic:777777"
+			String tokenId = channel.toString().split(":")[2];
+
+			// 3. STOMP 브로커를 통해 구독 중인 사용자들에게 전송
+			// 프론트 구독 주소 예: /topic/trades/777777
+			messagingTemplate.convertAndSend("/topic/trades/" + tokenId, msg);
+
+			System.out.println("WebSocket 전송 완료: [" + msg.getTakerSide() + "] " + tokenId + " -> " + msg.getTargetPrice());
+		});
+	}
+}

--- a/src/main/java/com/kanghwang/khholdings/domain/market/MarketWorker.java
+++ b/src/main/java/com/kanghwang/khholdings/domain/market/MarketWorker.java
@@ -9,7 +9,9 @@ import org.springframework.stereotype.Component;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import com.kanghwang.khholdings.domain.order.dto.OrderRequestDTO;
 import com.kanghwang.khholdings.domain.order.dto.TransactionRequestDTO;
+import com.kanghwang.khholdings.global.dto.RealTimeEvent;
 
 import jakarta.annotation.PostConstruct;
 import lombok.RequiredArgsConstructor;
@@ -29,11 +31,12 @@ public class MarketWorker {
 			.registerModule(new JavaTimeModule()) // Java 8 날짜 타입 지원 추가
 			.disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
 
+		// [체결]
 		// 1. Redis Topic 구독 (패턴 매칭 사용: 모든 토큰의 체결을 감시)
 		// JsonJacksonCodec을 사용하여 브라우저가 읽을 수 있는 JSON 형태로 받기
-		RPatternTopic topic = redissonClient.getPatternTopic("trade:topic:*", new JsonJacksonCodec(objectMapper));
+		RPatternTopic tradeTopic = redissonClient.getPatternTopic("trade:topic:*", new JsonJacksonCodec(objectMapper));
 
-		topic.addListener(TransactionRequestDTO.class, (pattern, channel, msg) -> {
+		tradeTopic.addListener(TransactionRequestDTO.class, (pattern, channel, msg) -> {
 			// 2. 체결 발생 시, 채널명에서 토큰 ID 추출
 			// 채널 예: "trade:topic:777777"
 			String tokenId = channel.toString().split(":")[2];
@@ -42,7 +45,31 @@ public class MarketWorker {
 			// 프론트 구독 주소 예: /topic/trades/777777
 			messagingTemplate.convertAndSend("/topic/trades/" + tokenId, msg);
 
-			System.out.println("WebSocket 전송 완료: [" + msg.getTakerSide() + "] " + tokenId + " -> " + msg.getTargetPrice());
+			System.out.println("[MarketWorker] WebSocket 체결: TradeID " + msg.getTradeId());
+		});
+
+		// [주문/호가]
+		RPatternTopic orderTopic = redissonClient.getPatternTopic("order:topic:*", new JsonJacksonCodec(objectMapper));
+
+		orderTopic.addListener(RealTimeEvent.class, (pattern, channel, event) -> {
+
+			String tokenId = channel.toString().split(":")[2];
+
+			messagingTemplate.convertAndSend("/topic/orders/" + tokenId, event);
+
+			String action = event.getAction();
+			Object data = event.getData();
+
+			// if ("INSERT".equals(action)) {
+			// 	OrderRequestDTO orderDTO = (OrderRequestDTO) data;
+			// 	System.out.println("[MarketWorker] WebSocket 주문 입력: OrderID " + orderDTO.getOrderId());
+			// } else
+			if ("UPDATE".equals(action)) {
+				OrderRequestDTO orderDTO = (OrderRequestDTO) data;
+				System.out.println("[MarketWorker] WebSocket 주문 등록: OrderID " + orderDTO.getOrderId());
+			} else {
+				System.out.println("[MarketWorker] WebSocket 주문 삭제: OrderID " + data);
+			}
 		});
 	}
 }

--- a/src/main/java/com/kanghwang/khholdings/domain/order/OrderController.java
+++ b/src/main/java/com/kanghwang/khholdings/domain/order/OrderController.java
@@ -35,8 +35,8 @@ public class OrderController {
 
 	// 매수/매도 주문
 	@PostMapping
-	public ResponseEntity<String> placeOrder(@RequestBody OrderRequestDTO orderDto) {
-		orderService.placeOrder(orderDto);
+	public ResponseEntity<String> placeOrder(@RequestBody OrderRequestDTO orderDTO) {
+		orderService.placeOrder(orderDTO);
 		return ResponseEntity.ok("주문이 완료되었습니다.");
 	}
 

--- a/src/main/java/com/kanghwang/khholdings/domain/order/OrderRepository.java
+++ b/src/main/java/com/kanghwang/khholdings/domain/order/OrderRepository.java
@@ -5,6 +5,7 @@ import java.math.BigDecimal;
 import org.apache.ibatis.annotations.Mapper;
 
 import com.kanghwang.khholdings.domain.order.dto.OrderRequestDTO;
+import com.kanghwang.khholdings.domain.order.dto.RefundRequestDTO;
 import com.kanghwang.khholdings.domain.order.dto.TransactionRequestDTO;
 
 @Mapper
@@ -14,10 +15,10 @@ public interface OrderRepository {
 
 	BigDecimal selectAvailableBalance(Long walletId);
 
-	void callPlaceOrderProcedure(OrderRequestDTO orderDto);
+	void callPlaceOrderProcedure(OrderRequestDTO orderDTO);
 
 	void p_process_transaction_hists(TransactionRequestDTO transactionDTO);
 
-	void p_cancel_order_and_refund(Long txId, Long orderId, BigDecimal remainingCash, BigDecimal remainingToken);
+	void p_cancel_order_and_refund(RefundRequestDTO refundDTO);
 
 }

--- a/src/main/java/com/kanghwang/khholdings/domain/order/TradeWorker.java
+++ b/src/main/java/com/kanghwang/khholdings/domain/order/TradeWorker.java
@@ -5,15 +5,17 @@ import java.util.Map;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 
-import org.redisson.RedissonShutdownException;
 import org.redisson.api.RStream;
 import org.redisson.api.RedissonClient;
 import org.redisson.api.StreamMessageId;
 import org.redisson.api.stream.StreamReadArgs;
-import org.redisson.codec.SerializationCodec;
+import org.redisson.codec.JsonJacksonCodec;
 import org.springframework.boot.CommandLineRunner;
 import org.springframework.stereotype.Service;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import com.kanghwang.khholdings.domain.order.dto.RefundRequestDTO;
 import com.kanghwang.khholdings.domain.order.dto.TransactionRequestDTO;
 
@@ -55,7 +57,12 @@ public class TradeWorker implements CommandLineRunner {
 
     private void processStream() {
 
-        RStream<String, Object> stream = redissonClient.getStream("trade:stream:", new SerializationCodec());
+        // Jackson이 OffsetDateTime을 읽을 있도록 JavaTimeModule 등록
+        ObjectMapper objectMapper = new ObjectMapper()
+            .registerModule(new JavaTimeModule()) // Java 8 날짜 타입 지원 추가
+            .disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
+
+        RStream<String, Object> stream = redissonClient.getStream("trade:stream:", new JsonJacksonCodec(objectMapper));
         StreamMessageId lastId = StreamMessageId.ALL; // 처음부터 혹은 최신부터 읽기 설정 가능
 
         while (isRunning) {
@@ -69,15 +76,16 @@ public class TradeWorker implements CommandLineRunner {
                 if (messages.isEmpty()) continue;
 
                 for (Map.Entry<StreamMessageId, Map<String, Object>> entry : messages.entrySet()) {
-                    Map<String, Object> dataMap = entry.getValue();
-                    Object payload = dataMap.get("data");
+                    Object data = entry.getValue().get("data");
                     try {
-                        if(payload instanceof TransactionRequestDTO) {
+                        if(data instanceof TransactionRequestDTO) {
                             // 1. 체결 정산 처리
-                            handleTransaction((TransactionRequestDTO) payload);
-                        } else if (payload instanceof RefundRequestDTO) {
+                            TransactionRequestDTO transactionDTO = objectMapper.convertValue(data, TransactionRequestDTO.class);
+                            handleTransaction(transactionDTO);
+                        } else if (data instanceof RefundRequestDTO) {
                             // 2. 취소 및 환불 처리
-                            handleRefund((RefundRequestDTO) payload);
+                            RefundRequestDTO refundDTO = objectMapper.convertValue(data, RefundRequestDTO.class);
+                            handleRefund(refundDTO);
                         }
 
                         stream.remove(lastId);   // Redis에서 정산 완료한 데이터 제거
@@ -88,16 +96,15 @@ public class TradeWorker implements CommandLineRunner {
                     }
                 }
             } catch (Exception e) {
-                // 앱 종료 중 Redisson이 먼저 꺼져서 에러가 날 수 있음 (정상)
-                if (!isRunning && (e instanceof RedissonShutdownException || e.getCause() instanceof RedissonShutdownException)) {
-                    log.info("[TradeWorker] 종료 중 Redisson 연결이 먼저 해제됨 (정상)");
-                } else {
-                    log.error("[TradeWorker] 오류 발생: ", e);
-                }
-                break; // 루프 탈출
-            } finally {
-                shutdownLatch.countDown(); // 래치의 await 풀기
+                log.error("[TradeWorker] 오류 발생: ", e);
+                break;
+            }
+
+            try {
+                shutdownLatch.countDown(); // await로 인해 기다리던 래치 풀어주기
                 log.info("[TradeWorker] 워커 스레드가 안전하게 루프를 종료했습니다.");
+            } catch (Exception e) {
+                log.error("[TradeWorker] 종료 정리 중 오류: ", e);
             }
         }
     }

--- a/src/main/java/com/kanghwang/khholdings/domain/order/TradeWorker.java
+++ b/src/main/java/com/kanghwang/khholdings/domain/order/TradeWorker.java
@@ -115,7 +115,7 @@ public class TradeWorker implements CommandLineRunner {
     // [환불/취소] DB 프로시저 호출
     private void handleRefund(RefundRequestDTO refundDTO) {
         try {
-            orderRepository.p_cancel_order_and_refund(refundDTO.getTxId(), refundDTO.getOrderId(), refundDTO.getRemainingCash(), refundDTO.getRemainingToken());
+            orderRepository.p_cancel_order_and_refund(refundDTO);
             log.info("[TradeWorker] 환불/취소 처리 완료: OrderID {}", refundDTO.getOrderId());
         } catch (Exception e) {
             log.error("[TradeWorker] 환불/취소 처리 실패: {}", e.getMessage());

--- a/src/main/java/com/kanghwang/khholdings/domain/order/dto/OrderRequestDTO.java
+++ b/src/main/java/com/kanghwang/khholdings/domain/order/dto/OrderRequestDTO.java
@@ -5,13 +5,17 @@ import java.math.BigDecimal;
 import com.kanghwang.khholdings.domain.order.type.OrderSide;
 import com.kanghwang.khholdings.domain.order.type.OrderType;
 
+import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 import lombok.Setter;
 
 @Getter
 @Setter
 @Builder
+@AllArgsConstructor
+@NoArgsConstructor
 public class OrderRequestDTO {
 	private Long orderId;             // order_id, 주문 고유 번호
 	private Long walletId;            // wallet_id, 지갑 번호

--- a/src/main/java/com/kanghwang/khholdings/domain/order/service/OrderRedisService.java
+++ b/src/main/java/com/kanghwang/khholdings/domain/order/service/OrderRedisService.java
@@ -10,9 +10,13 @@ import org.redisson.api.RMap;
 import org.redisson.api.RScoredSortedSet;
 import org.redisson.api.RedissonClient;
 import org.redisson.api.stream.StreamAddArgs;
+import org.redisson.codec.JsonJacksonCodec;
 import org.redisson.codec.SerializationCodec;
 import org.springframework.stereotype.Service;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import com.kanghwang.khholdings.domain.order.dto.OrderRequestDTO;
 import com.kanghwang.khholdings.domain.order.dto.RefundRequestDTO;
 import com.kanghwang.khholdings.domain.order.dto.TransactionRequestDTO;
@@ -77,6 +81,11 @@ public class OrderRedisService {
 		}
 		myOrderBook.add(score.doubleValue(), myOrderId); // 해당 토큰 호가창에 내 주문 등록
 		infoMap.put(myOrderId, myOrderDTO); // 해당 토큰 주문 상세에 내 주문 등록
+
+		// Jackson이 OffsetDateTime을 읽을 있도록 JavaTimeModule 등록
+		ObjectMapper objectMapper = new ObjectMapper()
+			.registerModule(new JavaTimeModule()) // Java 8 날짜 타입 지원 추가
+			.disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS); // ISO-8601 형식(문자열)으로 전송
 
 		while (true) {
 
@@ -186,7 +195,7 @@ public class OrderRedisService {
 
 			// (2) 실시간 프론트엔드 전파용 (Pub/Sub)
 			// WebSocketWorker가 받아서 웹소켓으로 전송
-			redissonClient.getTopic("trade:topic:" + myOrderDTO.getTokenId())
+			redissonClient.getTopic("trade:topic:" + myOrderDTO.getTokenId(), new JsonJacksonCodec(objectMapper))
 					.publish(transactionDTO);
 
 			// (3) 현재가 갱신 (예: "ticker:last_price:{tokenId}")

--- a/src/main/java/com/kanghwang/khholdings/domain/order/service/OrderRedisService.java
+++ b/src/main/java/com/kanghwang/khholdings/domain/order/service/OrderRedisService.java
@@ -11,7 +11,6 @@ import org.redisson.api.RScoredSortedSet;
 import org.redisson.api.RedissonClient;
 import org.redisson.api.stream.StreamAddArgs;
 import org.redisson.codec.JsonJacksonCodec;
-import org.redisson.codec.SerializationCodec;
 import org.springframework.stereotype.Service;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -22,6 +21,7 @@ import com.kanghwang.khholdings.domain.order.dto.RefundRequestDTO;
 import com.kanghwang.khholdings.domain.order.dto.TransactionRequestDTO;
 import com.kanghwang.khholdings.domain.order.type.OrderSide;
 import com.kanghwang.khholdings.domain.order.type.OrderType;
+import com.kanghwang.khholdings.global.dto.RealTimeEvent;
 import com.kanghwang.khholdings.global.util.RedisKeyManager;
 import com.kanghwang.khholdings.global.util.SnowflakeIdGenerator;
 
@@ -32,6 +32,11 @@ import lombok.extern.slf4j.Slf4j;
 @Service
 @RequiredArgsConstructor
 public class OrderRedisService {
+
+	// Jackson이 OffsetDateTime을 읽을 있도록 JavaTimeModule 등록
+	ObjectMapper objectMapper = new ObjectMapper()
+		.registerModule(new JavaTimeModule()) // Java 8 날짜 타입 지원 추가
+		.disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
 
 	private final RedissonClient redissonClient;
 	private static final BigDecimal F_RATE = new BigDecimal("0.0006"); // 수수료 관리
@@ -61,6 +66,7 @@ public class OrderRedisService {
 
 	// 매칭 엔진
 	private void executeMatching(OrderRequestDTO myOrderDTO) {
+
 		Long myOrderId = myOrderDTO.getOrderId();
 		OrderSide mySide = myOrderDTO.getOrderSide();
 		OrderSide counterSide = (myOrderDTO.getOrderSide() == OrderSide.BUY) ? OrderSide.SELL : OrderSide.BUY;
@@ -69,9 +75,9 @@ public class OrderRedisService {
 		String counterOrderBookKey = RedisKeyManager.getOrderBookKey(myOrderDTO.getTokenId(), counterSide);
 		String orderInfoKey = RedisKeyManager.getOrderInfoKey(myOrderDTO.getTokenId());
 
-		RScoredSortedSet<Long> myOrderBook = redissonClient.getScoredSortedSet(myOrderBookKey); // 매수(매도) 호가창 ('가격':'주문번호')
-		RScoredSortedSet<Long> counterOrderBook = redissonClient.getScoredSortedSet(counterOrderBookKey); // 매도(매수) 호가창 ('가격':'주문번호')
-		RMap<Long, OrderRequestDTO> infoMap = redissonClient.getMap(orderInfoKey); // 매수 및 매도 주문 상세 ('주문번호':'주문상세(DTO)')
+		RScoredSortedSet<Long> myOrderBook = redissonClient.getScoredSortedSet(myOrderBookKey, new JsonJacksonCodec(objectMapper)); // 매수(매도) 호가창 ('가격':'주문번호')
+		RScoredSortedSet<Long> counterOrderBook = redissonClient.getScoredSortedSet(counterOrderBookKey, new JsonJacksonCodec(objectMapper)); // 매도(매수) 호가창 ('가격':'주문번호')
+		RMap<Long, OrderRequestDTO> infoMap = redissonClient.getMap(orderInfoKey, new JsonJacksonCodec(objectMapper)); // 매수 및 매도 주문 상세 ('주문번호':'주문상세(DTO)')
 
 		// 주문 요청 시, 호가창에 선등록 (후체결)
 		BigDecimal score = myOrderDTO.getOrderPrice(); // 내 주문 가격
@@ -82,10 +88,11 @@ public class OrderRedisService {
 		myOrderBook.add(score.doubleValue(), myOrderId); // 해당 토큰 호가창에 내 주문 등록
 		infoMap.put(myOrderId, myOrderDTO); // 해당 토큰 주문 상세에 내 주문 등록
 
-		// Jackson이 OffsetDateTime을 읽을 있도록 JavaTimeModule 등록
-		ObjectMapper objectMapper = new ObjectMapper()
-			.registerModule(new JavaTimeModule()) // Java 8 날짜 타입 지원 추가
-			.disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS); // ISO-8601 형식(문자열)으로 전송
+		// 지정가 주문 정보를 실시간으로 전파 -> MarketWorker가 받아서 웹소켓으로 전송
+		// if (myOrderDTO.getOrderType() == OrderType.LIMIT) {
+		// 	RealTimeEvent<OrderRequestDTO> event = new RealTimeEvent<>("INSERT", myOrderDTO);
+		// 	redissonClient.getTopic("order:topic:" + myOrderDTO.getTokenId(), new JsonJacksonCodec(objectMapper)).publish(event);
+		// }
 
 		while (true) {
 
@@ -185,16 +192,17 @@ public class OrderRedisService {
 			TransactionRequestDTO transactionDTO = new TransactionRequestDTO(txId1, txId2, txId3, txId4, tradeId, buyOrderId, sellOrderId, targetPrice, executedVolume, F_RATE,
 				OffsetDateTime.now(), mySide);
 
-			// 체결이 발생할 때마다 Redis에 데이터 저장
+			// 체결이 발생할 때마다 Redis에 데이터 전달
+			// -> DB 저장 / 웹소켓 실시간 전송
 
 			// (1) 비동기 정산 및 이력 저장용 (Stream)
 			// TradeWorker가 받아서 프로시저 실행
 			// 현금 및 토큰 정산, 주문 내역 업데이트, 거래 내역 추가
-			redissonClient.getStream("trade:stream:", new SerializationCodec())
+			redissonClient.getStream("trade:stream:", new JsonJacksonCodec(objectMapper))
 					.add(StreamAddArgs.entry("data", transactionDTO));
 
 			// (2) 실시간 프론트엔드 전파용 (Pub/Sub)
-			// WebSocketWorker가 받아서 웹소켓으로 전송
+			// 체결 내역을 MarketWorker가 받아서 웹소켓으로 전송
 			redissonClient.getTopic("trade:topic:" + myOrderDTO.getTokenId(), new JsonJacksonCodec(objectMapper))
 					.publish(transactionDTO);
 
@@ -203,8 +211,8 @@ public class OrderRedisService {
 			redissonClient.getBucket("ticker:last_price:" + myOrderDTO.getTokenId())
 					.set(targetPrice);
 
-			log.info("[체결 완료] Price {}, Volume {}, Amount {}", targetPrice.toPlainString(), executedVolume.toPlainString(), executedAmount.toPlainString());
-			log.info("Redis에 체결 정보 전송 완료 : TradeID {}, Price {}, TakerSide {}", tradeId, targetPrice, mySide);
+			log.info("체결: Price {}, Volume {}, Amount {}", targetPrice.toPlainString(), executedVolume.toPlainString(), executedAmount.toPlainString());
+			log.info("Worker에게 나머지 작업 전달: TradeID {}", tradeId);
 
 			// [Step 4] 자산 정산 (미체결 수량 및 금액 갱신)
 			// 1) 나
@@ -227,14 +235,21 @@ public class OrderRedisService {
 			// [Step 5] 호가창 업데이트
 			// 1) 나
 			infoMap.put(myOrderId, myOrderDTO);
+
 			// 2) 상대방
 			if (targetOrderDTO.getRemainingToken().compareTo(BigDecimal.ZERO) <= 0) {
 				// 1) 0보다 작거나 같으면, 해당 주문을 호가창에서 제거 (매칭 X)
-				removeOrder(myOrderDTO.getTokenId(), counterSide, targetOrderId);
 				log.info("주문 전량 체결 완료: OrderId {}", targetOrderId);
+				removeOrder(myOrderDTO.getTokenId(), counterSide, targetOrderId);
 			} else {
 				// 2) 0보다 크면, 주문 상세 업데이트
 				infoMap.put(targetOrderId, targetOrderDTO);
+
+				// 지정가 주문 정보를 실시간으로 전파 -> MarketWorker가 받아서 웹소켓으로 전송
+				if (targetOrderDTO.getOrderType() == OrderType.LIMIT) {
+					RealTimeEvent<OrderRequestDTO> event = new RealTimeEvent<>("UPDATE", targetOrderDTO);
+					redissonClient.getTopic("order:topic:" + targetOrderDTO.getTokenId(), new JsonJacksonCodec(objectMapper)).publish(event);
+				}
 			}
 		}
 
@@ -266,7 +281,7 @@ public class OrderRedisService {
 					&& myOrderDTO.getRemainingCash().compareTo(BigDecimal.ZERO) > 0) {
 				// 비동기 정산 및 이력 저장용 Stream에 저장 후 DB 프로시저 호출
 				RefundRequestDTO refundRequestDTO = new RefundRequestDTO(SnowflakeIdGenerator.nextId(), myOrderDTO.getOrderId(), myOrderDTO.getRemainingCash(), BigDecimal.ZERO);
-				redissonClient.getStream("trade:stream:", new SerializationCodec())
+				redissonClient.getStream("trade:stream:", new JsonJacksonCodec(objectMapper))
 					.add(StreamAddArgs.entry("data", refundRequestDTO));
 				log.info("지정가 매수 차액 환불: 주문ID {}, 환불금액 {}", myOrderDTO.getOrderId(), myOrderDTO.getRemainingCash());
 			}
@@ -278,12 +293,16 @@ public class OrderRedisService {
 				// 1) 시장가 주문은 미체결 수량 즉시 환불
 				// 비동기 정산 및 이력 저장용 Stream에 저장 후 DB 프로시저 호출
 				RefundRequestDTO refundRequestDTO = new RefundRequestDTO(SnowflakeIdGenerator.nextId(), myOrderDTO.getOrderId(), myOrderDTO.getRemainingCash(), myOrderDTO.getRemainingToken());
-				redissonClient.getStream("trade:stream:", new SerializationCodec())
+				redissonClient.getStream("trade:stream:", new JsonJacksonCodec(objectMapper))
 					.add(StreamAddArgs.entry("data", refundRequestDTO));
 				log.info("시장가 주문 매칭 종료로 잔량 환불: OrderId {}", myOrderDTO.getOrderId());
 			} else {
 				// 2) 지정가 주문은 이미 [Step 5]에서 업데이트
 				log.info("지정가 주문 잔량 대기: OrderId {}, RemainingToken {}", myOrderDTO.getOrderId(), myOrderDTO.getRemainingToken());
+
+				// 웹소켓에서 주문(호가) 정보 업데이트
+				RealTimeEvent<OrderRequestDTO> event = new RealTimeEvent<>("UPDATE", myOrderDTO);
+				redissonClient.getTopic("order:topic:" + myOrderDTO.getTokenId(), new JsonJacksonCodec(objectMapper)).publish(event);
 			}
 		}
 	}
@@ -297,6 +316,9 @@ public class OrderRedisService {
 		redissonClient.getScoredSortedSet(bookKey).remove(orderId); // 호가창에서 삭제
 		redissonClient.getMap(infoKey).remove(orderId); // 주문 상세에서 삭제
 
+		// 웹소켓에서 주문(호가) 정보 삭제
+		RealTimeEvent<Long> event = new RealTimeEvent<>("DELETE", orderId);
+		redissonClient.getTopic("order:topic:" + tokenId, new JsonJacksonCodec(objectMapper)).publish(event);
 	}
 
 	// 주문 취소 (사용자가 직접)
@@ -316,10 +338,10 @@ public class OrderRedisService {
 
 			// 3. 비동기 정산 및 이력 저장용 Stream에 저장 후 DB 프로시저 호출
 			RefundRequestDTO refundRequestDTO = new RefundRequestDTO(SnowflakeIdGenerator.nextId(), orderId, orderInfo.getRemainingCash(), orderInfo.getRemainingToken());
-			redissonClient.getStream("trade:stream:", new SerializationCodec())
+			redissonClient.getStream("trade:stream:", new JsonJacksonCodec(objectMapper))
 				.add(StreamAddArgs.entry("data", refundRequestDTO));
 
-			log.info("[Engine] 주문 취소 신호 발행 완료: OrderId {}", orderId);
+			log.info("TradeWorker에 주문 취소 요청: OrderId {}", orderId);
 			return true;
 		} catch (Exception e) {
 			log.error("취소 처리 중 오류 발생: {}", e.getMessage());

--- a/src/main/java/com/kanghwang/khholdings/domain/order/service/OrderService.java
+++ b/src/main/java/com/kanghwang/khholdings/domain/order/service/OrderService.java
@@ -67,8 +67,8 @@ public class OrderService {
 		TransactionSynchronizationManager.registerSynchronization(new TransactionSynchronization() {
 			@Override
 			public void afterCommit() {
+				log.info("매칭 엔진에 주문 추가: {}", orderDTO.getOrderId());
 				orderRedisService.processOrder(orderDTO);
-				log.info("[OrderService] DB 커밋 완료 후 Redis 엔진에 주문 추가: {}", orderDTO.getOrderId());
 			}
 		});
 	}

--- a/src/main/java/com/kanghwang/khholdings/domain/order/service/OrderService.java
+++ b/src/main/java/com/kanghwang/khholdings/domain/order/service/OrderService.java
@@ -39,36 +39,36 @@ public class OrderService {
 
 	// 매수/매도 주문
 	@Transactional
-	public void placeOrder(OrderRequestDTO orderDto) {
+	public void placeOrder(OrderRequestDTO orderDTO) {
 
 		// 1. Snowflake ID를 사용하여 주문 번호 생성
 		Long orderId = snowflakeIdGenerator.nextId();
-		orderDto.setOrderId(orderId);
+		orderDTO.setOrderId(orderId);
 
 		// 2. 주문 요청 시, 미체결 금액 및 미체결 수량 초기화
 		// 1) 미체결 금액: 매수(BUY)는 총 주문 금액으로, 매도(SELL)은 0으로 초기화
-		if (orderDto.getOrderSide() == OrderSide.BUY) {
-			orderDto.setRemainingCash(orderDto.getTotalPrice());
+		if (orderDTO.getOrderSide() == OrderSide.BUY) {
+			orderDTO.setRemainingCash(orderDTO.getTotalPrice());
 		} else {
-			orderDto.setRemainingCash(BigDecimal.ZERO);
+			orderDTO.setRemainingCash(BigDecimal.ZERO);
 		}
 
 		// 2) 미체결 수량: 시장가 매수(MARKET, BUY)는 0으로, 그 외는 총 주문 수량으로 초기화
-		if (orderDto.getOrderType() == OrderType.MARKET && orderDto.getOrderSide() == OrderSide.BUY) {
-			orderDto.setRemainingToken(BigDecimal.ZERO);
+		if (orderDTO.getOrderType() == OrderType.MARKET && orderDTO.getOrderSide() == OrderSide.BUY) {
+			orderDTO.setRemainingToken(BigDecimal.ZERO);
 		} else {
-			orderDto.setRemainingToken(orderDto.getOrderVolume());
+			orderDTO.setRemainingToken(orderDTO.getOrderVolume());
 		}
 
 		// 3. DB에서 최소 주문 금액(수량) 확인, 자산 검증 및 동결, 주문 생성
-		orderDBService.placeOrder(orderDto);
+		orderDBService.placeOrder(orderDTO);
 
 		// 4. DB에서 주문 생성 후, Redis 매칭 엔진에 추가
 		TransactionSynchronizationManager.registerSynchronization(new TransactionSynchronization() {
 			@Override
 			public void afterCommit() {
-				orderRedisService.processOrder(orderDto);
-				log.info("[OrderService] DB 커밋 완료 후 Redis 엔진에 주문 추가: {}", orderDto.getOrderId());
+				orderRedisService.processOrder(orderDTO);
+				log.info("[OrderService] DB 커밋 완료 후 Redis 엔진에 주문 추가: {}", orderDTO.getOrderId());
 			}
 		});
 	}

--- a/src/main/java/com/kanghwang/khholdings/global/config/WebSocketConfig.java
+++ b/src/main/java/com/kanghwang/khholdings/global/config/WebSocketConfig.java
@@ -1,0 +1,28 @@
+package com.kanghwang.khholdings.global.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.messaging.simp.config.MessageBrokerRegistry;
+import org.springframework.web.socket.config.annotation.EnableWebSocketMessageBroker;
+import org.springframework.web.socket.config.annotation.StompEndpointRegistry;
+import org.springframework.web.socket.config.annotation.WebSocketMessageBrokerConfigurer;
+
+@Configuration
+@EnableWebSocketMessageBroker
+public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
+
+	@Override
+	public void registerStompEndpoints(StompEndpointRegistry registry) {
+		// 프론트가 연결할 엔드포인트: ws://localhost:8080/ws-stomp
+		registry.addEndpoint("/ws-stomp")
+			.setAllowedOriginPatterns("*") // 테스트용 모든 도메인 허용
+			.withSockJS(); // 구형 브라우저 지원용
+	}
+
+	@Override
+	public void configureMessageBroker(MessageBrokerRegistry registry) {
+		// 서버가 사용자에게 메시지를 보낼 때 (구독 경로)
+		registry.enableSimpleBroker("/topic");
+		// 사용자가 서버로 메시지를 보낼 때 (보내는 경로)
+		registry.setApplicationDestinationPrefixes("/app");
+	}
+}

--- a/src/main/java/com/kanghwang/khholdings/global/dto/RealTimeEvent.java
+++ b/src/main/java/com/kanghwang/khholdings/global/dto/RealTimeEvent.java
@@ -1,0 +1,15 @@
+package com.kanghwang.khholdings.global.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@AllArgsConstructor
+@NoArgsConstructor
+public class RealTimeEvent<T> {
+	private String action; // "INSERT", "UPDATE", "DELETE"
+	private T data;        // 실제 데이터
+}

--- a/src/main/resources/mapper/OrderMapper.xml
+++ b/src/main/resources/mapper/OrderMapper.xml
@@ -52,7 +52,7 @@
         )
     </update>
 
-    <update id="p_cancel_order_and_refund" statementType="CALLABLE">
+    <update id="p_cancel_order_and_refund" parameterType="RefundRequestDTO" statementType="CALLABLE">
         CALL p_cancel_order_and_refund(
             #{txId},
             #{orderId},


### PR DESCRIPTION
## 📌 작업 내용 요약 (Summary)
- 호가/체결 내역을 [Redis 매칭 엔진 -> Redis Stream/Topic -> WebSocket]으로 전파
- WebSocket으로 데이터 전달 시, JSON 타입으로 직렬화/역직렬화

## 📝 변경 사항 (Key Changes)
- [ ] MarketWorker에 리스너 등록 - Redis에서 호가/체결 발생 후 기록 시, Websocket을 통해 브라우저에 전달
- [ ] 직렬화/역직렬화 시 데이터 변환 방법 변경 : SerializationCodec() -> JsonJacksonCodec(objectMapper)
- [ ] 환불/취소 프로시저 호출 시, RefundRequestDTO로 전달 + mapper 수정
- [ ] WebSocketConfig 작성

## 📸 스크린샷 (Screenshots / Demos)
| Feature | Screenshot |
| :--- | :--- |
| 기능명 | 사진첨부 |

## 🔗 연관된 이슈 (Related Issues)
- Close #38 
- Close #39 

## 🧐 주요 리뷰 포인트 (Review Point)
- 

## ✅ 최종 PR전 체크 리스트 (Checklist)
- [ ] 코딩 컨벤션(Checkstyle)을 준수하였는가?
- [ ] 불필요한 주석이나 시스템 로그(console.log, print)를 제거하였는가?
- [ ] 변경 사항에 대한 테스트를 완료하였는가?
- [ ] 관련 문서를 업데이트하였는가?
