### PR TITLE
[FEAT] 배당 스냅샷, 배당 정산, 토큰 소각 구현

### DIFF
--- a/src/main/java/com/kanghwang/khholdings/domain/market/MarketRepository.java
+++ b/src/main/java/com/kanghwang/khholdings/domain/market/MarketRepository.java
@@ -1,5 +1,6 @@
 package com.kanghwang.khholdings.domain.market;
 
+import java.math.BigDecimal;
 import java.util.List;
 
 import org.apache.ibatis.annotations.Mapper;
@@ -9,7 +10,10 @@ import com.kanghwang.khholdings.domain.market.dto.MarketDTO;
 @Mapper
 public interface MarketRepository {
 
-	public abstract List<MarketDTO> selectAll();
+	List<MarketDTO> selectAll();
 
-	public abstract List<MarketDTO> selectBySearch(String content);
+	List<MarketDTO> selectBySearch(String content);
+
+	// 특정 토큰 현재가 조회
+	BigDecimal selectLatestTokenPrice(Long tokenId);
 }

--- a/src/main/java/com/kanghwang/khholdings/domain/project/ProjectController.java
+++ b/src/main/java/com/kanghwang/khholdings/domain/project/ProjectController.java
@@ -1,71 +1,113 @@
-package com.kanghwang.khholdings.domain.project;
-
-import java.math.BigDecimal;
-import java.util.Map;
-
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.RestController;
-
-@RestController
-@RequestMapping("/api/project")
-public class ProjectController {
-
-	@Autowired
-	private ProjectService projectService;
-
-	// 청약 신청
-	@PostMapping("/application/{tokenId}")
-	public ResponseEntity<?> applySubscription(@PathVariable Long tokenId,
-											   @RequestParam Long subscriptionId,
-											   @RequestParam Long walletId,
-											   @RequestParam BigDecimal amount) {
-
-		try {
-			Long txHistId = projectService.applySubscription(tokenId, subscriptionId, walletId, amount);
-			return ResponseEntity.ok(Map.of(
-				"transactionId", txHistId,
-				"message", "청약 신청이 완료되었습니다."
-			));
-		} catch (RuntimeException e) {
-			// "청약 신청에 실패했습니다."
-			return ResponseEntity.badRequest().body(Map.of(
-				"message", e.getMessage()
-			));
-		}
-	}
-
-	// 청약 취소
-	@PostMapping("/cancel/{transactionId}")
-	public ResponseEntity<?> cancelSubscription(@PathVariable Long transactionId) {
-
-		boolean isCancelled = projectService.cancelSubscription(transactionId);
-
-		if (isCancelled) {
-			return ResponseEntity.ok("청약 취소가 완료되었습니다.");
-		} else {
-			return ResponseEntity.badRequest().body("청약 취소에 실패했습니다.");
-		}
-
-	}
-
-	// 청약 정산 (당첨, 낙첨)
-	@PostMapping("/result/{transactionId}")
-	public ResponseEntity<?> resultSubscription(@PathVariable Long transactionId, 
-												@RequestParam Long tokenId, 
-												@RequestParam Long passPrice, 
-												@RequestParam Long passVolume) {
-
-		boolean isCompleted = projectService.resultSubscription(transactionId, tokenId, passPrice, passVolume);
-
-		if (isCompleted) {
-			return ResponseEntity.ok("청약 정산이 완료되었습니다.");
-		} else {
-			return ResponseEntity.badRequest().body("청약 정산에 실패했습니다.");
-		}
-	}
-}
+// package com.kanghwang.khholdings.domain.project;
+//
+// import java.math.BigDecimal;
+// import java.util.List;
+// import java.util.Map;
+//
+// import org.springframework.beans.factory.annotation.Autowired;
+// import org.springframework.http.ResponseEntity;
+// import org.springframework.web.bind.annotation.PathVariable;
+// import org.springframework.web.bind.annotation.PostMapping;
+// import org.springframework.web.bind.annotation.RequestMapping;
+// import org.springframework.web.bind.annotation.RequestParam;
+// import org.springframework.web.bind.annotation.RestController;
+//
+// import com.kanghwang.khholdings.domain.project.dto.DividendDTO;
+//
+// @RestController
+// @RequestMapping("/api/project")
+// public class ProjectController {
+//
+// 	@Autowired
+// 	private ProjectService projectService;
+//
+// 	// 청약 신청
+// 	@PostMapping("/application/{tokenId}")
+// 	public ResponseEntity<?> applySubscription(@PathVariable Long tokenId,
+// 											   @RequestParam Long subscriptionId,
+// 											   @RequestParam Long walletId,
+// 											   @RequestParam BigDecimal amount) {
+//
+// 		try {
+// 			Long txHistId = projectService.applySubscription(tokenId, subscriptionId, walletId, amount);
+// 			return ResponseEntity.ok(Map.of(
+// 				"transactionId", txHistId,
+// 				"message", "청약 신청이 완료되었습니다."
+// 			));
+// 		} catch (RuntimeException e) {
+// 			// "청약 신청에 실패했습니다."
+// 			return ResponseEntity.badRequest().body(Map.of(
+// 				"message", e.getMessage()
+// 			));
+// 		}
+// 	}
+//
+// 	// 청약 취소
+// 	@PostMapping("/cancel/{transactionId}")
+// 	public ResponseEntity<?> cancelSubscription(@PathVariable Long transactionId) {
+//
+// 		boolean isCancelled = projectService.cancelSubscription(transactionId);
+//
+// 		if (isCancelled) {
+// 			return ResponseEntity.ok("청약 취소가 완료되었습니다.");
+// 		} else {
+// 			return ResponseEntity.badRequest().body("청약 취소에 실패했습니다.");
+// 		}
+//
+// 	}
+//
+// 	// 청약 정산 (당첨, 낙첨)
+// 	@PostMapping("/result/{transactionId}")
+// 	public ResponseEntity<?> resultSubscription(@PathVariable Long transactionId,
+// 												@RequestParam Long tokenId,
+// 												@RequestParam Long passPrice,
+// 												@RequestParam Long passVolume) {
+//
+// 		boolean isCompleted = projectService.resultSubscription(transactionId, tokenId, passPrice, passVolume);
+//
+// 		if (isCompleted) {
+// 			return ResponseEntity.ok("청약 정산이 완료되었습니다.");
+// 		} else {
+// 			return ResponseEntity.badRequest().body("청약 정산에 실패했습니다.");
+// 		}
+// 	}
+//
+// 	// 배당 스냅샷
+// 	@PostMapping("/dividend/before/{transactionId}")
+// 	public ResponseEntity<?> resultSnapshot(@PathVariable Long tokenId) {
+//
+// 		List<DividendDTO> list = projectService.resultSnapshot(tokenId);
+//
+// 		if (!list.isEmpty()) {
+// 			return ResponseEntity.ok("배당 스냅샷 완료되었습니다.");
+// 		} else {
+// 			return ResponseEntity.badRequest().body("배당 스냅샷 실패했습니다.");
+// 		}
+// 	}
+//
+// 	// 배당 정산
+// 	@PostMapping("/dividend/after/{walletId}")
+// 	public ResponseEntity<?> resultDividend(@PathVariable Long walletId) {
+//
+// 		boolean isCompleted = resultDividend.resultSnapshot(walletId);
+//
+// 		if (isCompleted) {
+// 			return ResponseEntity.ok("배당 스냅샷 완료되었습니다.");
+// 		} else {
+// 			return ResponseEntity.badRequest().body("배당 스냅샷 실패했습니다.");
+// 		}
+// 	}
+//
+// 	// 토큰 소각
+// 	@PostMapping("/close/{transactionId}")
+// 	public ResponseEntity<?> closeToken(@PathVariable Long tokenId) {
+//
+// 		boolean isCompleted = closeToken.resultSnapshot(tokenId);
+//
+// 		if (isCompleted) {
+// 			return ResponseEntity.ok("배당 스냅샷 완료되었습니다.");
+// 		} else {
+// 			return ResponseEntity.badRequest().body("배당 스냅샷 실패했습니다.");
+// 		}
+// 	}
+// }

--- a/src/main/java/com/kanghwang/khholdings/domain/project/ProjectController.java
+++ b/src/main/java/com/kanghwang/khholdings/domain/project/ProjectController.java
@@ -1,113 +1,109 @@
-// package com.kanghwang.khholdings.domain.project;
-//
-// import java.math.BigDecimal;
-// import java.util.List;
-// import java.util.Map;
-//
-// import org.springframework.beans.factory.annotation.Autowired;
-// import org.springframework.http.ResponseEntity;
-// import org.springframework.web.bind.annotation.PathVariable;
-// import org.springframework.web.bind.annotation.PostMapping;
-// import org.springframework.web.bind.annotation.RequestMapping;
-// import org.springframework.web.bind.annotation.RequestParam;
-// import org.springframework.web.bind.annotation.RestController;
-//
-// import com.kanghwang.khholdings.domain.project.dto.DividendDTO;
-//
-// @RestController
-// @RequestMapping("/api/project")
-// public class ProjectController {
-//
-// 	@Autowired
-// 	private ProjectService projectService;
-//
-// 	// 청약 신청
-// 	@PostMapping("/application/{tokenId}")
-// 	public ResponseEntity<?> applySubscription(@PathVariable Long tokenId,
-// 											   @RequestParam Long subscriptionId,
-// 											   @RequestParam Long walletId,
-// 											   @RequestParam BigDecimal amount) {
-//
-// 		try {
-// 			Long txHistId = projectService.applySubscription(tokenId, subscriptionId, walletId, amount);
-// 			return ResponseEntity.ok(Map.of(
-// 				"transactionId", txHistId,
-// 				"message", "청약 신청이 완료되었습니다."
-// 			));
-// 		} catch (RuntimeException e) {
-// 			// "청약 신청에 실패했습니다."
-// 			return ResponseEntity.badRequest().body(Map.of(
-// 				"message", e.getMessage()
-// 			));
-// 		}
-// 	}
-//
-// 	// 청약 취소
-// 	@PostMapping("/cancel/{transactionId}")
-// 	public ResponseEntity<?> cancelSubscription(@PathVariable Long transactionId) {
-//
-// 		boolean isCancelled = projectService.cancelSubscription(transactionId);
-//
-// 		if (isCancelled) {
-// 			return ResponseEntity.ok("청약 취소가 완료되었습니다.");
-// 		} else {
-// 			return ResponseEntity.badRequest().body("청약 취소에 실패했습니다.");
-// 		}
-//
-// 	}
-//
-// 	// 청약 정산 (당첨, 낙첨)
-// 	@PostMapping("/result/{transactionId}")
-// 	public ResponseEntity<?> resultSubscription(@PathVariable Long transactionId,
-// 												@RequestParam Long tokenId,
-// 												@RequestParam Long passPrice,
-// 												@RequestParam Long passVolume) {
-//
-// 		boolean isCompleted = projectService.resultSubscription(transactionId, tokenId, passPrice, passVolume);
-//
-// 		if (isCompleted) {
-// 			return ResponseEntity.ok("청약 정산이 완료되었습니다.");
-// 		} else {
-// 			return ResponseEntity.badRequest().body("청약 정산에 실패했습니다.");
-// 		}
-// 	}
-//
-// 	// 배당 스냅샷
-// 	@PostMapping("/dividend/before/{transactionId}")
-// 	public ResponseEntity<?> resultSnapshot(@PathVariable Long tokenId) {
-//
-// 		List<DividendDTO> list = projectService.resultSnapshot(tokenId);
-//
-// 		if (!list.isEmpty()) {
-// 			return ResponseEntity.ok("배당 스냅샷 완료되었습니다.");
-// 		} else {
-// 			return ResponseEntity.badRequest().body("배당 스냅샷 실패했습니다.");
-// 		}
-// 	}
-//
-// 	// 배당 정산
-// 	@PostMapping("/dividend/after/{walletId}")
-// 	public ResponseEntity<?> resultDividend(@PathVariable Long walletId) {
-//
-// 		boolean isCompleted = resultDividend.resultSnapshot(walletId);
-//
-// 		if (isCompleted) {
-// 			return ResponseEntity.ok("배당 스냅샷 완료되었습니다.");
-// 		} else {
-// 			return ResponseEntity.badRequest().body("배당 스냅샷 실패했습니다.");
-// 		}
-// 	}
-//
-// 	// 토큰 소각
-// 	@PostMapping("/close/{transactionId}")
-// 	public ResponseEntity<?> closeToken(@PathVariable Long tokenId) {
-//
-// 		boolean isCompleted = closeToken.resultSnapshot(tokenId);
-//
-// 		if (isCompleted) {
-// 			return ResponseEntity.ok("배당 스냅샷 완료되었습니다.");
-// 		} else {
-// 			return ResponseEntity.badRequest().body("배당 스냅샷 실패했습니다.");
-// 		}
-// 	}
-// }
+ package com.kanghwang.khholdings.domain.project;
+
+ import java.math.BigDecimal;
+ import java.util.List;
+ import java.util.Map;
+
+ import com.kanghwang.khholdings.domain.project.dto.SnapshotDTO;
+ import org.springframework.beans.factory.annotation.Autowired;
+ import org.springframework.http.ResponseEntity;
+ import org.springframework.web.bind.annotation.*;
+
+ import com.kanghwang.khholdings.domain.project.dto.DividendDTO;
+
+ @RestController
+ @RequestMapping("/api/project")
+ public class ProjectController {
+
+ 	@Autowired
+ 	private ProjectService projectService;
+
+ 	// 청약 신청
+ 	@PostMapping("/application/{tokenId}")
+ 	public ResponseEntity<?> applySubscription(@PathVariable Long tokenId,
+ 											   @RequestParam Long subscriptionId,
+ 											   @RequestParam Long walletId,
+ 											   @RequestParam BigDecimal amount) {
+
+ 		try {
+ 			Long txHistId = projectService.applySubscription(tokenId, subscriptionId, walletId, amount);
+ 			return ResponseEntity.ok(Map.of(
+ 				"transactionId", txHistId,
+ 				"message", "청약 신청이 완료되었습니다."
+ 			));
+ 		} catch (RuntimeException e) {
+ 			// "청약 신청에 실패했습니다."
+ 			return ResponseEntity.badRequest().body(Map.of(
+ 				"message", e.getMessage()
+ 			));
+ 		}
+ 	}
+
+ 	// 청약 취소
+ 	@PostMapping("/cancel/{transactionId}")
+ 	public ResponseEntity<?> cancelSubscription(@PathVariable Long transactionId) {
+
+ 		boolean isCancelled = projectService.cancelSubscription(transactionId);
+
+ 		if (isCancelled) {
+ 			return ResponseEntity.ok("청약 취소가 완료되었습니다.");
+ 		} else {
+ 			return ResponseEntity.badRequest().body("청약 취소에 실패했습니다.");
+ 		}
+
+ 	}
+
+ 	// 청약 정산 (당첨, 낙첨)
+ 	@PostMapping("/result/{transactionId}")
+ 	public ResponseEntity<?> resultSubscription(@PathVariable Long transactionId,
+ 												@RequestParam Long tokenId,
+ 												@RequestParam Long passPrice,
+ 												@RequestParam Long passVolume) {
+
+ 		boolean isCompleted = projectService.resultSubscription(transactionId, tokenId, passPrice, passVolume);
+
+ 		if (isCompleted) {
+ 			return ResponseEntity.ok("청약 정산이 완료되었습니다.");
+ 		} else {
+ 			return ResponseEntity.badRequest().body("청약 정산에 실패했습니다.");
+ 		}
+ 	}
+
+ 	// 배당 스냅샷
+ 	@PostMapping("/dividend/before/{tokenId}")
+ 	public ResponseEntity<?> resultSnapshot(@PathVariable Long tokenId) {
+
+ 		List<SnapshotDTO> list = projectService.resultSnapshot(tokenId);
+
+ 		if (list.isEmpty()) {
+ 			return ResponseEntity.badRequest().body("배당 스냅샷 실패했습니다.");
+ 		}
+		return ResponseEntity.ok(list);
+ 	}
+
+ 	// 배당 정산
+ 	@PostMapping("/dividend/after/{walletId}")
+ 	public ResponseEntity<?> resultDividend(@ModelAttribute DividendDTO dividendDTO) {
+
+ 		boolean isCompleted = projectService.resultDividend(dividendDTO);
+
+ 		if (isCompleted) {
+ 			return ResponseEntity.ok("배당 정산이 완료되었습니다.");
+ 		} else {
+ 			return ResponseEntity.badRequest().body("배당 정산에 실패했습니다.");
+ 		}
+ 	}
+
+ 	// 토큰 소각
+ 	@PostMapping("/close/{tokenId}")
+ 	public ResponseEntity<?> burnToken(@PathVariable Long tokenId) {
+
+ 		boolean isCompleted = projectService.burnToken(tokenId);
+
+ 		if (isCompleted) {
+ 			return ResponseEntity.ok("토큰 소각 및 정산이 완료되었습니다.");
+ 		} else {
+ 			return ResponseEntity.badRequest().body("토큰 소각에 실패했습니다.");
+ 		}
+ 	}
+ }

--- a/src/main/java/com/kanghwang/khholdings/domain/project/ProjectController.java
+++ b/src/main/java/com/kanghwang/khholdings/domain/project/ProjectController.java
@@ -83,9 +83,9 @@
 
  	// 배당 정산
  	@PostMapping("/dividend/after/{walletId}")
- 	public ResponseEntity<?> resultDividend(@ModelAttribute DividendDTO dividendDTO) {
+ 	public ResponseEntity<?> resultDividend(@RequestBody List<DividendDTO> divList) {
 
- 		boolean isCompleted = projectService.resultDividend(dividendDTO);
+ 		boolean isCompleted = projectService.resultDividend(divList);
 
  		if (isCompleted) {
  			return ResponseEntity.ok("배당 정산이 완료되었습니다.");

--- a/src/main/java/com/kanghwang/khholdings/domain/project/ProjectRepository.java
+++ b/src/main/java/com/kanghwang/khholdings/domain/project/ProjectRepository.java
@@ -1,8 +1,11 @@
 package com.kanghwang.khholdings.domain.project;
 
 import java.math.BigDecimal;
+import java.util.List;
 
 import org.apache.ibatis.annotations.Mapper;
+
+import com.kanghwang.khholdings.domain.project.dto.DividendDTO;
 
 @Mapper
 public interface ProjectRepository {
@@ -12,5 +15,11 @@ public interface ProjectRepository {
 	boolean cancelSubscription(Long transactionId, Long newTransactionId, String hashValue);
 
 	boolean resultSubscription(Long transactionId, Long tokenId, Long passTransactionId, Long failTransactionId, Long passPrice, Long passVolume, String passHashValue, String failHashValue);
+
+	List<DividendDTO> resultSnapshot(Long tokenId);
+
+	boolean resultDividend(Long transactionId, Long dividendId, Long walletId, BigDecimal amount, String hashValue);
+
+	boolean closeToken(Long transactionId, Long tokenId);
 
 }

--- a/src/main/java/com/kanghwang/khholdings/domain/project/ProjectRepository.java
+++ b/src/main/java/com/kanghwang/khholdings/domain/project/ProjectRepository.java
@@ -2,6 +2,7 @@ package com.kanghwang.khholdings.domain.project;
 
 import java.math.BigDecimal;
 import java.util.List;
+import java.util.Map;
 
 import com.kanghwang.khholdings.domain.project.dto.BurnDTO;
 import com.kanghwang.khholdings.domain.project.dto.SnapshotDTO;
@@ -21,15 +22,21 @@ public interface ProjectRepository {
 	// 청약 정산 (당첨, 낙첨)
 	boolean resultSubscription(Long transactionId, Long tokenId, Long passTransactionId, Long failTransactionId, Long passPrice, Long passVolume, String passHashValue, String failHashValue);
 
-	// 배당 스냅샷
+	// 배당 스냅샷 (반환용)
 	List<SnapshotDTO> resultSnapshot(Long tokenId);
 
+	// 배당 스냅샷 (저장용)
+	void insertSnapshot(List<SnapshotDTO> list);
+
 	// 배당 정산
-	boolean resultDividend(DividendDTO dividendDTO);
+	void resultDividend(List<DividendDTO> dividendDTO);
 
 	// 토큰 소각
 	void burnTokenBatch(List<BurnDTO> list);
 
 	// 토큰 삭제
 	void deleteToken(Long tokenId);
+
+	// 토큰 존재 여부 확인
+	Map<String, Object> checkTokenStatus(Long tokenId);
 }

--- a/src/main/java/com/kanghwang/khholdings/domain/project/ProjectRepository.java
+++ b/src/main/java/com/kanghwang/khholdings/domain/project/ProjectRepository.java
@@ -3,6 +3,8 @@ package com.kanghwang.khholdings.domain.project;
 import java.math.BigDecimal;
 import java.util.List;
 
+import com.kanghwang.khholdings.domain.project.dto.BurnDTO;
+import com.kanghwang.khholdings.domain.project.dto.SnapshotDTO;
 import org.apache.ibatis.annotations.Mapper;
 
 import com.kanghwang.khholdings.domain.project.dto.DividendDTO;
@@ -10,16 +12,24 @@ import com.kanghwang.khholdings.domain.project.dto.DividendDTO;
 @Mapper
 public interface ProjectRepository {
 
+	// 청약 신청
 	Long applySubscription(Long transactionId, Long tokenId, Long subscriptionId, Long walletId, BigDecimal amount, String hashValue);
 
+	// 청약 취소
 	boolean cancelSubscription(Long transactionId, Long newTransactionId, String hashValue);
 
+	// 청약 정산 (당첨, 낙첨)
 	boolean resultSubscription(Long transactionId, Long tokenId, Long passTransactionId, Long failTransactionId, Long passPrice, Long passVolume, String passHashValue, String failHashValue);
 
-	List<DividendDTO> resultSnapshot(Long tokenId);
+	// 배당 스냅샷
+	List<SnapshotDTO> resultSnapshot(Long tokenId);
 
-	boolean resultDividend(Long transactionId, Long dividendId, Long walletId, BigDecimal amount, String hashValue);
+	// 배당 정산
+	boolean resultDividend(DividendDTO dividendDTO);
 
-	boolean closeToken(Long transactionId, Long tokenId);
+	// 토큰 소각
+	void burnTokenBatch(List<BurnDTO> list);
 
+	// 토큰 삭제
+	void deleteToken(Long tokenId);
 }

--- a/src/main/java/com/kanghwang/khholdings/domain/project/ProjectService.java
+++ b/src/main/java/com/kanghwang/khholdings/domain/project/ProjectService.java
@@ -1,83 +1,152 @@
-// package com.kanghwang.khholdings.domain.project;
-//
-// import java.math.BigDecimal;
-// import java.util.List;
-//
-// import org.apache.commons.codec.digest.DigestUtils;
-// import org.springframework.beans.factory.annotation.Autowired;
-// import org.springframework.stereotype.Service;
-// import org.springframework.transaction.annotation.Transactional;
-//
-// import com.kanghwang.khholdings.domain.project.dto.DividendDTO;
-// import com.kanghwang.khholdings.global.util.SnowflakeIdGenerator;
-//
-// @Service
-// public class ProjectService {
-//
-// 	@Autowired
-// 	private ProjectRepository projectRepository;
-//
-// 	@Transactional
-// 	public Long applySubscription(Long tokenId, Long subscriptionId, Long walletId, BigDecimal amount) {
-//
-// 		// 1. Snowflake ID 생성
-// 		Long transactionId = SnowflakeIdGenerator.nextId();
-//
-// 		// 2. 해시값 생성
-// 		String hashValue = DigestUtils.sha256Hex(transactionId.toString() + walletId.toString());
-//
-// 		Long txHistId = projectRepository.applySubscription(transactionId, tokenId, subscriptionId, walletId, amount, hashValue);
-//
-// 		// 3. 결과 검증
-// 		if (txHistId == null) {
-// 			throw new RuntimeException("청약 신청에 실패했습니다.");
-// 		}
-//
-// 		return txHistId;
-// 	}
-//
-// 	@Transactional
-// 	public boolean cancelSubscription(Long transactionId) {
-//
-// 		// 1. Snowflake ID 생성
-// 		Long newTransactionId = SnowflakeIdGenerator.nextId();
-//
-// 		// 2. 해시값 생성
-// 		String hashValue = DigestUtils.sha256Hex(transactionId.toString());
-//
-// 		return projectRepository.cancelSubscription(transactionId, newTransactionId, hashValue);
-// 	}
-//
-// 	@Transactional
-// 	public boolean resultSubscription(Long transactionId, Long tokenId, Long passPrice, Long passVolume) {
-//
-// 		// 1. Snowflake ID 생성
-// 		Long passTxId = SnowflakeIdGenerator.nextId();
-// 		Long failTxId = SnowflakeIdGenerator.nextId();
-//
-// 		// 2. 해시값 생성
-// 		String passHashValue = DigestUtils.sha256Hex(transactionId.toString());
-// 		String failHashValue = DigestUtils.sha256Hex(transactionId.toString());
-//
-// 		return projectRepository.resultSubscription(transactionId, tokenId, passTxId, failTxId, passPrice, passVolume, passHashValue, failHashValue);
-// 	}
-//
-// 	// 배당 스앱샷
-// 	public List<DividendDTO> resultSnapshot(Long tokenId) {
-// 		return projectRepository.resultSnapshot(tokenId);
-// 	}
-//
-// 	// 배당 정산
-// 	public boolean resultDividend(Long tokenId) {
-//
-// 		Long transactionId = SnowflakeIdGenerator.nextId();
-// 		String hashValue = DigestUtils.sha256Hex(transactionId.toString() + walletId.toString());
-//
-// 		return projectRepository.resultDividend(transactionId, dividendId, walletId, amount, hashValue);
-// 	}
-//
-// 	// 토큰 소각
-// 	public boolean closeToken(Long transactionId, Long tokenId) {
-// 		return projectRepository.closeToken(transactionId, tokenId);
-// 	}
-// }
+package com.kanghwang.khholdings.domain.project;
+
+import java.math.BigDecimal;
+import java.util.ArrayList;
+import java.util.List;
+
+import com.kanghwang.khholdings.domain.market.MarketRepository;
+import com.kanghwang.khholdings.domain.project.dto.BurnDTO;
+import com.kanghwang.khholdings.domain.project.dto.SnapshotDTO;
+import lombok.RequiredArgsConstructor;
+import org.apache.commons.codec.digest.DigestUtils;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.kanghwang.khholdings.domain.project.dto.DividendDTO;
+import com.kanghwang.khholdings.global.util.SnowflakeIdGenerator;
+
+@Service
+@RequiredArgsConstructor
+public class ProjectService {
+
+	private final ProjectRepository projectRepository;
+	private final MarketRepository marketRepository;
+
+	// 청약 신청
+	@Transactional
+	public Long applySubscription(Long tokenId, Long subscriptionId, Long walletId, BigDecimal amount) {
+
+		// 1. Snowflake ID 생성
+		Long transactionId = SnowflakeIdGenerator.nextId();
+
+		// 2. 해시값 생성
+		String hashValue = DigestUtils.sha256Hex(transactionId.toString() + walletId.toString());
+
+		Long txHistId = projectRepository.applySubscription(transactionId, tokenId, subscriptionId, walletId, amount,
+				hashValue);
+
+		// 3. 결과 검증
+		if (txHistId == null) {
+			throw new RuntimeException("청약 신청에 실패했습니다.");
+		}
+
+		return txHistId;
+	}
+
+	// 청약 취소
+	@Transactional
+	public boolean cancelSubscription(Long transactionId) {
+
+		// 1. Snowflake ID 생성
+		Long newTransactionId = SnowflakeIdGenerator.nextId();
+
+		// 2. 해시값 생성
+		String hashValue = DigestUtils.sha256Hex(transactionId.toString());
+
+		return projectRepository.cancelSubscription(transactionId, newTransactionId, hashValue);
+	}
+
+	// 청약 정산 (당첨, 낙첨)
+	@Transactional
+	public boolean resultSubscription(Long transactionId, Long tokenId, Long passPrice, Long passVolume) {
+
+		// 1. Snowflake ID 생성
+		Long passTxId = SnowflakeIdGenerator.nextId();
+		Long failTxId = SnowflakeIdGenerator.nextId();
+
+		// 2. 해시값 생성
+		String passHashValue = DigestUtils.sha256Hex(transactionId.toString());
+		String failHashValue = DigestUtils.sha256Hex(transactionId.toString());
+
+		return projectRepository.resultSubscription(transactionId, tokenId, passTxId, failTxId, passPrice, passVolume,
+				passHashValue, failHashValue);
+	}
+
+	// 배당 스앱샷
+	public List<SnapshotDTO> resultSnapshot(Long tokenId) {
+		return projectRepository.resultSnapshot(tokenId);
+	}
+
+	// 배당 정산
+	@Transactional
+	public boolean resultDividend(DividendDTO dividendDTO) {
+
+		Long transactionId = SnowflakeIdGenerator.nextId();
+
+		dividendDTO.setTransactionId(transactionId);
+		dividendDTO.setHashValue(transactionId.toString() + transactionId.toString());
+
+		return projectRepository.resultDividend(dividendDTO);
+	}
+
+	// 토큰 소각
+	@Transactional
+	public boolean burnToken(Long tokenId) {
+
+		// 1. 단가 조회
+		BigDecimal tradePrice = marketRepository.selectLatestTokenPrice(tokenId);
+		if (tradePrice == null) {
+			throw new RuntimeException("현재 시세를 찾을 수 없습니다.");
+		}
+
+		// 2. 대상자 조회
+		List<SnapshotDTO> holders = projectRepository.resultSnapshot(tokenId);
+		if (holders == null || holders.isEmpty()) {
+			throw new RuntimeException("토큰 보유 대상자가 없습니다.");
+		}
+
+		// 3. batch 처리
+		final int BATCH_SIZE = 1000;
+		List<BurnDTO> list = new ArrayList<>(BATCH_SIZE);
+
+		for (SnapshotDTO holder : holders) {
+
+			BigDecimal tokenBalance = holder.getTokenBalance();
+			BigDecimal calcCash = tokenBalance.multiply(tradePrice);
+
+			Long txId1 = SnowflakeIdGenerator.nextId();
+			Long txId2 = SnowflakeIdGenerator.nextId();
+
+			BurnDTO burnDTO = BurnDTO.builder()
+				.walletId(holder.getWalletId())
+				.tokenId(holder.getTokenId())
+				.txId1(txId1)
+				.txId2(txId2)
+				.amount(tokenBalance)
+				.cashAmount(calcCash)
+				.hashValue1(DigestUtils.sha256Hex(txId1.toString()))
+				.hashValue2(DigestUtils.sha256Hex(txId2.toString()))
+				.build();
+
+			list.add(burnDTO);
+
+			// 배치 실행
+			if (list.size() >= BATCH_SIZE) {
+				projectRepository.burnTokenBatch(list);
+				list.clear();
+			}
+
+		}
+
+		// 남은 데이터 처리
+		if (!list.isEmpty()) {
+			projectRepository.burnTokenBatch(list);
+		}
+
+		// 토큰 삭제
+		projectRepository.deleteToken(tokenId);
+
+		return true;
+	}
+}

--- a/src/main/java/com/kanghwang/khholdings/domain/project/ProjectService.java
+++ b/src/main/java/com/kanghwang/khholdings/domain/project/ProjectService.java
@@ -1,62 +1,83 @@
-package com.kanghwang.khholdings.domain.project;
-
-import java.math.BigDecimal;
-
-import org.apache.commons.codec.digest.DigestUtils;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
-
-import com.kanghwang.khholdings.global.util.SnowflakeIdGenerator;
-
-@Service
-public class ProjectService {
-
-	@Autowired
-	private ProjectRepository projectRepository;
-
-	@Transactional
-	public Long applySubscription(Long tokenId, Long subscriptionId, Long walletId, BigDecimal amount) {
-
-		// 1. Snowflake ID 생성
-		Long transactionId = SnowflakeIdGenerator.nextId();
-
-		// 2. 해시값 생성
-		String hashValue = DigestUtils.sha256Hex(transactionId.toString() + walletId.toString());
-
-		Long txHistId = projectRepository.applySubscription(transactionId, tokenId, subscriptionId, walletId, amount, hashValue);
-
-		// 3. 결과 검증
-		if (txHistId == null) {
-			throw new RuntimeException("청약 신청에 실패했습니다.");
-		}
-
-		return txHistId;
-	}
-
-	@Transactional
-	public boolean cancelSubscription(Long transactionId) {
-
-		// 1. Snowflake ID 생성
-		Long newTransactionId = SnowflakeIdGenerator.nextId();
-
-		// 2. 해시값 생성
-		String hashValue = DigestUtils.sha256Hex(transactionId.toString());
-
-		return projectRepository.cancelSubscription(transactionId, newTransactionId, hashValue);
-	}
-
-	@Transactional
-	public boolean resultSubscription(Long transactionId, Long tokenId, Long passPrice, Long passVolume) {
-
-		// 1. Snowflake ID 생성
-		Long passTxId = SnowflakeIdGenerator.nextId();
-		Long failTxId = SnowflakeIdGenerator.nextId();
-
-		// 2. 해시값 생성
-		String passHashValue = DigestUtils.sha256Hex(transactionId.toString());
-		String failHashValue = DigestUtils.sha256Hex(transactionId.toString());
-
-		return projectRepository.resultSubscription(transactionId, tokenId, passTxId, failTxId, passPrice, passVolume, passHashValue, failHashValue);
-	}
-}
+// package com.kanghwang.khholdings.domain.project;
+//
+// import java.math.BigDecimal;
+// import java.util.List;
+//
+// import org.apache.commons.codec.digest.DigestUtils;
+// import org.springframework.beans.factory.annotation.Autowired;
+// import org.springframework.stereotype.Service;
+// import org.springframework.transaction.annotation.Transactional;
+//
+// import com.kanghwang.khholdings.domain.project.dto.DividendDTO;
+// import com.kanghwang.khholdings.global.util.SnowflakeIdGenerator;
+//
+// @Service
+// public class ProjectService {
+//
+// 	@Autowired
+// 	private ProjectRepository projectRepository;
+//
+// 	@Transactional
+// 	public Long applySubscription(Long tokenId, Long subscriptionId, Long walletId, BigDecimal amount) {
+//
+// 		// 1. Snowflake ID 생성
+// 		Long transactionId = SnowflakeIdGenerator.nextId();
+//
+// 		// 2. 해시값 생성
+// 		String hashValue = DigestUtils.sha256Hex(transactionId.toString() + walletId.toString());
+//
+// 		Long txHistId = projectRepository.applySubscription(transactionId, tokenId, subscriptionId, walletId, amount, hashValue);
+//
+// 		// 3. 결과 검증
+// 		if (txHistId == null) {
+// 			throw new RuntimeException("청약 신청에 실패했습니다.");
+// 		}
+//
+// 		return txHistId;
+// 	}
+//
+// 	@Transactional
+// 	public boolean cancelSubscription(Long transactionId) {
+//
+// 		// 1. Snowflake ID 생성
+// 		Long newTransactionId = SnowflakeIdGenerator.nextId();
+//
+// 		// 2. 해시값 생성
+// 		String hashValue = DigestUtils.sha256Hex(transactionId.toString());
+//
+// 		return projectRepository.cancelSubscription(transactionId, newTransactionId, hashValue);
+// 	}
+//
+// 	@Transactional
+// 	public boolean resultSubscription(Long transactionId, Long tokenId, Long passPrice, Long passVolume) {
+//
+// 		// 1. Snowflake ID 생성
+// 		Long passTxId = SnowflakeIdGenerator.nextId();
+// 		Long failTxId = SnowflakeIdGenerator.nextId();
+//
+// 		// 2. 해시값 생성
+// 		String passHashValue = DigestUtils.sha256Hex(transactionId.toString());
+// 		String failHashValue = DigestUtils.sha256Hex(transactionId.toString());
+//
+// 		return projectRepository.resultSubscription(transactionId, tokenId, passTxId, failTxId, passPrice, passVolume, passHashValue, failHashValue);
+// 	}
+//
+// 	// 배당 스앱샷
+// 	public List<DividendDTO> resultSnapshot(Long tokenId) {
+// 		return projectRepository.resultSnapshot(tokenId);
+// 	}
+//
+// 	// 배당 정산
+// 	public boolean resultDividend(Long tokenId) {
+//
+// 		Long transactionId = SnowflakeIdGenerator.nextId();
+// 		String hashValue = DigestUtils.sha256Hex(transactionId.toString() + walletId.toString());
+//
+// 		return projectRepository.resultDividend(transactionId, dividendId, walletId, amount, hashValue);
+// 	}
+//
+// 	// 토큰 소각
+// 	public boolean closeToken(Long transactionId, Long tokenId) {
+// 		return projectRepository.closeToken(transactionId, tokenId);
+// 	}
+// }

--- a/src/main/java/com/kanghwang/khholdings/domain/project/ProjectService.java
+++ b/src/main/java/com/kanghwang/khholdings/domain/project/ProjectService.java
@@ -3,6 +3,7 @@ package com.kanghwang.khholdings.domain.project;
 import java.math.BigDecimal;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 
 import com.kanghwang.khholdings.domain.market.MarketRepository;
 import com.kanghwang.khholdings.domain.project.dto.BurnDTO;
@@ -74,25 +75,65 @@ public class ProjectService {
 	}
 
 	// 배당 스앱샷
+	@Transactional
 	public List<SnapshotDTO> resultSnapshot(Long tokenId) {
-		return projectRepository.resultSnapshot(tokenId);
+
+		List<SnapshotDTO> list = projectRepository.resultSnapshot(tokenId);
+
+		if (list != null && !list.isEmpty()) {
+			projectRepository.insertSnapshot(list);
+		}
+
+		return list;
 	}
 
 	// 배당 정산
 	@Transactional
-	public boolean resultDividend(DividendDTO dividendDTO) {
+	public boolean resultDividend(List<DividendDTO> divList) {
 
-		Long transactionId = SnowflakeIdGenerator.nextId();
+		if (divList == null || divList.size() == 0) {
+			return false;
+		}
 
-		dividendDTO.setTransactionId(transactionId);
-		dividendDTO.setHashValue(transactionId.toString() + transactionId.toString());
+		int BATCH_SIZE = 1000;
+		List<DividendDTO> batchBuffer = new ArrayList<>();
 
-		return projectRepository.resultDividend(dividendDTO);
+		for (DividendDTO dividendDTO : divList) {
+
+			Long transactionId = SnowflakeIdGenerator.nextId();
+
+			dividendDTO.setTransactionId(transactionId);
+			dividendDTO.setHashValue(transactionId.toString() + transactionId.toString());
+
+			batchBuffer.add(dividendDTO);
+
+			if (batchBuffer.size() >= BATCH_SIZE) {
+				projectRepository.resultDividend(batchBuffer);
+				batchBuffer.clear();
+			}
+		}
+
+		if (!batchBuffer.isEmpty()) {
+			projectRepository.resultDividend(batchBuffer);
+		}
+
+		return true;
 	}
 
 	// 토큰 소각
 	@Transactional
 	public boolean burnToken(Long tokenId) {
+
+		// 토큰 존재 여부 확인
+		Map<String, Object> tokenStatus = projectRepository.checkTokenStatus(tokenId);
+
+		if (tokenStatus == null) {
+			throw new RuntimeException("존재하지 않는 토큰입니다.");
+		}
+
+		if (tokenStatus.get("deleted_at") != null) {
+			throw new RuntimeException("이미 소각 처리된 토큰입니다.");
+		}
 
 		// 1. 단가 조회
 		BigDecimal tradePrice = marketRepository.selectLatestTokenPrice(tokenId);

--- a/src/main/java/com/kanghwang/khholdings/domain/project/dto/BurnDTO.java
+++ b/src/main/java/com/kanghwang/khholdings/domain/project/dto/BurnDTO.java
@@ -1,4 +1,22 @@
 package com.kanghwang.khholdings.domain.project.dto;
 
+import lombok.*;
+
+import java.math.BigDecimal;
+
+@Getter
+@Setter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
 public class BurnDTO {
+    private Long txId1;                 // 트랜잭션 ID 1 (토큰 차감)
+    private Long txId2;                 // 트랜잭션 ID 2 (현금 지급)
+    private Long tokenId;               // 토근 번호
+    private Long walletId;              // 지갑 번호
+    private String hashValue1;          // 해시 1
+    private String hashValue2;          // 해시 2
+    private BigDecimal amount;          // 소각 수량
+    private BigDecimal cashAmount;      // 소각 수량 * 토큰 현재 가격
+
 }

--- a/src/main/java/com/kanghwang/khholdings/domain/project/dto/BurnDTO.java
+++ b/src/main/java/com/kanghwang/khholdings/domain/project/dto/BurnDTO.java
@@ -1,0 +1,4 @@
+package com.kanghwang.khholdings.domain.project.dto;
+
+public class BurnDTO {
+}

--- a/src/main/java/com/kanghwang/khholdings/domain/project/dto/DividendDTO.java
+++ b/src/main/java/com/kanghwang/khholdings/domain/project/dto/DividendDTO.java
@@ -2,17 +2,17 @@ package com.kanghwang.khholdings.domain.project.dto;
 
 import java.math.BigDecimal;
 
-import lombok.AllArgsConstructor;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
-import lombok.Setter;
+import lombok.*;
 
 @Getter
 @Setter
+@Builder
 @NoArgsConstructor
 @AllArgsConstructor
 public class DividendDTO {
-	private Long userId;
-	private Long tokenId;
-	private BigDecimal tokenBalance;
+	private Long transactionId;
+	private Long dividendId;
+	private Long walletId;
+	private BigDecimal amount;
+	private String hashValue;
 }

--- a/src/main/java/com/kanghwang/khholdings/domain/project/dto/DividendDTO.java
+++ b/src/main/java/com/kanghwang/khholdings/domain/project/dto/DividendDTO.java
@@ -14,5 +14,6 @@ public class DividendDTO {
 	private Long dividendId;
 	private Long walletId;
 	private BigDecimal amount;
+	private BigDecimal fee;
 	private String hashValue;
 }

--- a/src/main/java/com/kanghwang/khholdings/domain/project/dto/DividendDTO.java
+++ b/src/main/java/com/kanghwang/khholdings/domain/project/dto/DividendDTO.java
@@ -1,0 +1,18 @@
+package com.kanghwang.khholdings.domain.project.dto;
+
+import java.math.BigDecimal;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class DividendDTO {
+	private Long userId;
+	private Long tokenId;
+	private BigDecimal tokenBalance;
+}

--- a/src/main/java/com/kanghwang/khholdings/domain/project/dto/SnapshotDTO.java
+++ b/src/main/java/com/kanghwang/khholdings/domain/project/dto/SnapshotDTO.java
@@ -1,0 +1,4 @@
+package com.kanghwang.khholdings.domain.project.dto;
+
+public class SnapshotDTO {
+}

--- a/src/main/java/com/kanghwang/khholdings/domain/project/dto/SnapshotDTO.java
+++ b/src/main/java/com/kanghwang/khholdings/domain/project/dto/SnapshotDTO.java
@@ -1,4 +1,17 @@
 package com.kanghwang.khholdings.domain.project.dto;
 
+import lombok.*;
+
+import java.math.BigDecimal;
+
+@Getter
+@Setter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
 public class SnapshotDTO {
+    private Long userId;				// 유저 아이디
+    private Long walletId;			    // 지갑 번호
+    private Long tokenId;		        // 토큰 번호
+    private BigDecimal tokenBalance;   // 보유 토큰 수량
 }

--- a/src/main/resources/mapper/MarketMapper.xml
+++ b/src/main/resources/mapper/MarketMapper.xml
@@ -69,4 +69,15 @@
         ORDER BY ds.daily_trade_volume DESC NULLS LAST
     </select>
 
+    <select id="selectLatestTokenPrice">
+        SELECT
+            trade_price
+        FROM
+            token_quotes
+        WHERE
+            token_id = #{tokenId}
+        ORDER BY
+            created_at DESC
+            LIMIT 1
+    </select>
 </mapper>

--- a/src/main/resources/mapper/ProjectMapper.xml
+++ b/src/main/resources/mapper/ProjectMapper.xml
@@ -120,19 +120,21 @@
         WHERE r.fail_amount > 0;
     </insert>
 
-    <select id="resultSnapshot" resultType="HoldingRequestDTO">
-        select
+    <select id="resultSnapshot" resultType="SnapshotDTO">
+        -- 배당 스냅샷
+        SELECT
             u.user_id,
+            w.wallet_id,
             h.token_id,
             h.token_balance
         FROM holdings h
-                 JOIN wallets w ON h.wallet_id = w.wallet_id
-                 JOIN users u ON w.user_id = u.user_id
-        WHERE h.token_balance > 0
-          and h.token_id = #{tokenId}
+            JOIN wallets w ON h.wallet_id = w.wallet_id
+            JOIN users u ON w.user_id = u.user_id
+        --WHERE h.token_balance > 0
+        AND h.token_id = #{tokenId}
     </select>
 
-    <select id="resultDividend">
+    <update id="resultDividend" parameterType="DividendDTO">
         -- 배당금 입급
         WITH updated_wallet AS (
             UPDATE wallets
@@ -147,25 +149,101 @@
             trade_id,
             wallet_id,
             transaction_type,
-            asset_type,
             direction,
+            asset_type,
             amount,
             balance_after,
-            remaining_price,
             hash_value
         )
        SELECT
-             #{transactionId},
-             #{tradeId},
-             #{walletId},
-             'DIVIDEND',
-             'CASH',
-             'IN',
-             #{amount},
-             cash_balance,
-             0,
-             #{hashValue}
+            #{transactionId},
+            #{dividendId},
+            #{walletId},
+            'DIVIDEND'::transaction_type_enum,
+            'IN'::direction_enum,
+            'CASH'::asset_type_enum,
+            #{amount},
+            uw.cash_balance,
+            #{hashValue}
         FROM
             updated_wallet uw
-    </select>
+    </update>
+
+    <update id="burnTokenBatch" parameterType="java.util.List">
+        -- 토큰 소각
+        WITH updates(wallet_id, token_id, sold_volume, cash_amount, tx_id1, tx_id2, h_val1, h_val2) AS (
+            VALUES
+            <foreach collection="list" item="item" separator=",">
+                (
+                 #{item.walletId}::bigint,
+                 #{item.tokenId}::bigint,
+                #{item.amount}::numeric,
+                #{item.cashAmount}::numeric,
+                #{item.txId1}::bigint,
+                #{item.txId2}::bigint,
+                #{item.hashValue1}::text,
+                #{item.hashValue2}::text
+                )
+            </foreach>
+        ),
+        deduct_holdings AS (
+            -- 2. 토큰 잔액 차감 및 차감 전 보유량 반환
+            UPDATE holdings h
+            SET
+                token_balance = h.token_balance - u.sold_volume,
+                purchased_value = 0,
+                updated_at = now()
+            FROM
+                updates u
+            WHERE h.token_id = u.token_id
+            AND h.wallet_id = u.wallet_id
+            RETURNING h.wallet_id, h.token_id
+        ),
+        update_wallet AS (
+            -- 3. 현금 잔액 증가
+            UPDATE wallets w
+            SET
+                cash_balance = w.cash_balance + u.cash_amount,
+                updated_at = now()
+            FROM updates u
+            WHERE w.wallet_id = u.wallet_id
+            RETURNING w.wallet_id, w.cash_balance as balance_after, u.token_id as orign_token_id
+        )
+        INSERT INTO transaction_hists (
+            transaction_id,
+            wallet_id,
+            transaction_type,
+            direction,
+            amount,
+            balance_after,
+            hash_value,
+            asset_type
+        )
+        SELECT
+            v.tx_id,
+            u.wallet_id,
+            'BURN'::transaction_type_enum,
+            v.t_dir,
+            v.t_amt,
+            v.t_bal,
+            v.t_hash,
+            v.t_asset
+        FROM updates u
+        JOIN update_wallet uw ON u.wallet_id = uw.wallet_id AND u.token_id = uw.orign_token_id
+        JOIN deduct_holdings dh ON u.wallet_id = dh.wallet_id AND u.token_id = dh.token_id
+        CROSS JOIN LATERAL (
+        VALUES
+            (u.tx_id1, 'OUT'::direction_enum, u.sold_volume, 0, u.h_val1, 'TOKEN'::asset_type_enum),
+            (u.tx_id2, 'IN'::direction_enum,  u.cash_amount, uw.balance_after, u.h_val2, 'CASH'::asset_type_enum)
+        ) AS v(tx_id, t_dir, t_amt, t_bal, t_hash, t_asset)
+    </update>
+
+    <update id="deleteToken">
+        UPDATE
+            tokens
+        SET
+            deleted_at = NOW()
+        WHERE
+            token_id = #{tokenId}
+    </update>
 </mapper>

--- a/src/main/resources/mapper/ProjectMapper.xml
+++ b/src/main/resources/mapper/ProjectMapper.xml
@@ -121,52 +121,72 @@
     </insert>
 
     <select id="resultSnapshot" resultType="SnapshotDTO">
-        -- 배당 스냅샷
+        -- 배당 스냅샷 (반환용)
         SELECT
             u.user_id,
             w.wallet_id,
             h.token_id,
             h.token_balance
         FROM holdings h
-            JOIN wallets w ON h.wallet_id = w.wallet_id
-            JOIN users u ON w.user_id = u.user_id
+        JOIN wallets w ON h.wallet_id = w.wallet_id
+        JOIN users u ON w.user_id = u.user_id
         --WHERE h.token_balance > 0
         AND h.token_id = #{tokenId}
     </select>
 
-    <update id="resultDividend" parameterType="DividendDTO">
-        -- 배당금 입급
-        WITH updated_wallet AS (
-            UPDATE wallets
-            SET cash_balance = cash_balance + #{amount},
-                updated_at = NOW()
-            WHERE wallet_id = #{walletId}
-            RETURNING cash_balance
-        )
-        -- 배당 내역 삽입
-        INSERT INTO transaction_hists (
-            transaction_id,
-            trade_id,
+    <insert id="insertSnapshot">
+        -- 배당 스냅샷 (저장용)
+        INSERT INTO dividend_hists (
+            token_id,
             wallet_id,
-            transaction_type,
-            direction,
-            asset_type,
-            amount,
-            balance_after,
-            hash_value
-        )
-       SELECT
-            #{transactionId},
-            #{dividendId},
-            #{walletId},
-            'DIVIDEND'::transaction_type_enum,
-            'IN'::direction_enum,
-            'CASH'::asset_type_enum,
-            #{amount},
-            uw.cash_balance,
-            #{hashValue}
-        FROM
-            updated_wallet uw
+            cur_token_balance
+        ) VALUES
+        <foreach collection="list" item="item" separator=",">
+            (
+            #{item.tokenId},
+            #{item.walletId},
+            #{item.tokenBalance}
+            )
+        </foreach>
+    </insert>
+
+    <update id="resultDividend" parameterType="java.util.List">
+        <foreach collection="list" item="item" separator=";">
+            -- 배당금 입급
+            WITH updated_wallet AS (
+                UPDATE wallets
+                SET cash_balance = cash_balance + #{item.amount} -#{item.fee},
+                    updated_at = NOW()
+                WHERE wallet_id = #{item.walletId}
+                RETURNING cash_balance
+            )
+            -- 배당 내역 삽입
+            INSERT INTO transaction_hists (
+                transaction_id,
+                trade_id,
+                wallet_id,
+                transaction_type,
+                direction,
+                asset_type,
+                amount,
+                balance_after,
+                hash_value,
+                fee
+            )
+           SELECT
+                #{item.transactionId},
+                #{item.dividendId},
+                #{item.walletId},
+                'DIVIDEND'::transaction_type_enum,
+                'IN'::direction_enum,
+                'CASH'::asset_type_enum,
+                #{item.amount},
+                uw.cash_balance,
+                #{item.hashValue},
+                #{item.fee}
+            FROM
+                updated_wallet uw
+        </foreach>
     </update>
 
     <update id="burnTokenBatch" parameterType="java.util.List">
@@ -246,4 +266,13 @@
         WHERE
             token_id = #{tokenId}
     </update>
+
+    <select id="checkTokenStatus" resultType="map">
+        -- 토큰 존재 여부 확인
+        SELECT
+            token_id,
+            deleted_at
+        FROM tokens
+        WHERE token_id = #{tokenId}
+    </select>
 </mapper>

--- a/src/main/resources/mapper/ProjectMapper.xml
+++ b/src/main/resources/mapper/ProjectMapper.xml
@@ -120,4 +120,52 @@
         WHERE r.fail_amount > 0;
     </insert>
 
+    <select id="resultSnapshot" resultType="HoldingRequestDTO">
+        select
+            u.user_id,
+            h.token_id,
+            h.token_balance
+        FROM holdings h
+                 JOIN wallets w ON h.wallet_id = w.wallet_id
+                 JOIN users u ON w.user_id = u.user_id
+        WHERE h.token_balance > 0
+          and h.token_id = #{tokenId}
+    </select>
+
+    <select id="resultDividend">
+        -- 배당금 입급
+        WITH updated_wallet AS (
+            UPDATE wallets
+            SET cash_balance = cash_balance + #{amount},
+                updated_at = NOW()
+            WHERE wallet_id = #{walletId}
+            RETURNING cash_balance
+        )
+        -- 배당 내역 삽입
+        INSERT INTO transaction_hists (
+            transaction_id,
+            trade_id,
+            wallet_id,
+            transaction_type,
+            asset_type,
+            direction,
+            amount,
+            balance_after,
+            remaining_price,
+            hash_value
+        )
+       SELECT
+             #{transactionId},
+             #{tradeId},
+             #{walletId},
+             'DIVIDEND',
+             'CASH',
+             'IN',
+             #{amount},
+             cash_balance,
+             0,
+             #{hashValue}
+        FROM
+            updated_wallet uw
+    </select>
 </mapper>


### PR DESCRIPTION
## 📌 작업 내용 요약 (Summary)
마리팜에서 배당 스냅샷 요청 시 당시 해당 토큰을 보유한 사람의 지갑 번호와 토큰 보유 수량을 보내줌
마리팜에서 토큰번호, 지갑번호, 정산액을 전송해주면 해당 지갑에 현금을 이체해줌
마리팜에서 토큰 소각 요청을 하면 현재가 * 토큰 보유 수량 만큼 현금을 지갑에 넣어줌
각각에 해당하는 체결 내역 insert

## 📝 변경 사항 (Key Changes)
- [ ] 
- [ ] 

## 📸 스크린샷 (Screenshots / Demos)
| Feature | Screenshot |
| :--- | :--- |
| 기능명 | 사진첨부 |

## 🔗 연관된 이슈 (Related Issues)
- Close #49 
- Close #50 
- Close #51 

## 🧐 주요 리뷰 포인트 (Review Point)
- ProjectController 왜 저렇게 다 변경됐다고 뜨는지 모르겠습니다 죄송합니다 아래에 배당 부분만 추가됐습니다

## ✅ 최종 PR전 체크 리스트 (Checklist)
- [ ] 코딩 컨벤션(Checkstyle)을 준수하였는가?
- [ ] 불필요한 주석이나 시스템 로그(console.log, print)를 제거하였는가?
- [ ] 변경 사항에 대한 테스트를 완료하였는가?
- [ ] 관련 문서를 업데이트하였는가?
