### PR TITLE
[FIX] 청약 정산 로직 수정, 응답값 형식 통일

### DIFF
--- a/src/main/java/com/kanghwang/khholdings/domain/market/MarketController.java
+++ b/src/main/java/com/kanghwang/khholdings/domain/market/MarketController.java
@@ -3,12 +3,14 @@ package com.kanghwang.khholdings.domain.market;
 import java.util.List;
 
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.kanghwang.khholdings.domain.market.dto.MarketDTO;
+import com.kanghwang.khholdings.global.dto.ApiResponse;
 
 @RestController
 @RequestMapping("/api/market")
@@ -18,12 +20,22 @@ public class MarketController {
 	private MarketService marketService;
 
 	@GetMapping()
-	public List<MarketDTO> selectAll() {
-		return marketService.selectAll();
+	public ResponseEntity<ApiResponse<List<MarketDTO>>> selectAll() {
+		List<MarketDTO> list = marketService.selectAll();
+
+		if (list == null || list.isEmpty()) {
+			return ResponseEntity.badRequest().body(ApiResponse.error("토큰 종목 조회에 실패했습니다."));
+		}
+		return ResponseEntity.ok(ApiResponse.success("토큰 종목 조회에 성공했습니다.", list));
 	}
 
 	@GetMapping("/search")
-	public List<MarketDTO> selectBySearch(@RequestParam(required = false) String content) {
-		 return marketService.selectBySearch(content);
+	public ResponseEntity<ApiResponse<List<MarketDTO>>> selectBySearch(@RequestParam(required = false) String content) {
+		List<MarketDTO> list = marketService.selectBySearch(content);
+
+		if (list == null || list.isEmpty()) {
+			return ResponseEntity.badRequest().body(ApiResponse.error("토큰 종목 검색에 실패했습니다."));
+		}
+		return ResponseEntity.ok(ApiResponse.success("토큰 종목 검색에 성공했습니다.", list));
 	}
 }

--- a/src/main/java/com/kanghwang/khholdings/domain/my/MyController.java
+++ b/src/main/java/com/kanghwang/khholdings/domain/my/MyController.java
@@ -1,13 +1,21 @@
 package com.kanghwang.khholdings.domain.my;
 
+import java.util.List;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.ModelAttribute;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
 import com.kanghwang.khholdings.domain.my.dto.HoldingDTO;
+import com.kanghwang.khholdings.domain.my.dto.TransactionHistDTO;
 import com.kanghwang.khholdings.domain.my.dto.TxHistsSearchDTO;
 import com.kanghwang.khholdings.domain.my.dto.WalletDTO;
-import com.kanghwang.khholdings.domain.order.dto.TransactionRequestDTO;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.web.bind.annotation.*;
-
-import java.util.List;
+import com.kanghwang.khholdings.global.dto.ApiResponse;
 
 @RestController
 @RequestMapping("/api/my")
@@ -18,25 +26,45 @@ public class MyController {
 
 	// 특정 계좌 및 지갑 조회
 	@GetMapping("/wallet/{walletId}")
-	public List<WalletDTO> selectWalletById(@PathVariable Long walletId){
-		return myService.selectWalletById(walletId);
+	public ResponseEntity<ApiResponse<List<WalletDTO>>> selectWalletById(@PathVariable Long walletId){
+		List<WalletDTO> list = myService.selectWalletById(walletId);
+
+		if (list == null || list.isEmpty()) {
+			return ResponseEntity.badRequest().body(ApiResponse.error("지갑 조회에 실패했습니다."));
+		}
+		return ResponseEntity.ok(ApiResponse.success("지갑 조회에 성공했습니다.", list));
 	}
 
 	// 보유 토큰 조회
 	@GetMapping("/token/{walletId}")
-	public List<HoldingDTO> selectTokenByWalletId(@PathVariable Long walletId, @RequestParam Integer page){
-		return myService.selectTokenByWalletId(walletId, page);
+	public ResponseEntity<ApiResponse<List<HoldingDTO>>> selectTokenByWalletId(@PathVariable Long walletId, @RequestParam Integer page){
+		List<HoldingDTO> list = myService.selectTokenByWalletId(walletId, page);
+
+		if (list == null || list.isEmpty()) {
+			return ResponseEntity.badRequest().body(ApiResponse.error("보유 토큰 조회에 실패했습니다."));
+		}
+		return ResponseEntity.ok(ApiResponse.success("보유 토큰 조회에 성공했습니다.", list));
 	}
 
 	// 나의 거래 내역 조회(필터 조회, 기간 조회, 페이징)
 	@GetMapping("/transaction")
-	public List<TransactionRequestDTO> selectTxHistByWalletId(@ModelAttribute TxHistsSearchDTO searchDTO){
-		return myService.selectTxHistByWalletId(searchDTO);
+	public ResponseEntity<ApiResponse<List<TransactionHistDTO>>> selectTxHistByWalletId(@ModelAttribute TxHistsSearchDTO searchDTO){
+		List<TransactionHistDTO> list = myService.selectTxHistByWalletId(searchDTO);
+
+		if (list == null || list.isEmpty()) {
+			return ResponseEntity.badRequest().body(ApiResponse.error("거래 내역 조회에 실패했습니다."));
+		}
+		return ResponseEntity.ok(ApiResponse.success("거래 내역 조회에 성공했습니다.", list));
 	}
 
 	// 계좌 연동
 	@GetMapping("/account/{userId}")
-	public Long selectAccount(@PathVariable Long userId){
-		return myService.selectAccount(userId);
+	public ResponseEntity<ApiResponse<Long>> selectAccount(@PathVariable Long userId){
+		Long walletId = myService.selectAccount(userId);
+
+		if (walletId == null) {
+			return ResponseEntity.badRequest().body(ApiResponse.error("계좌 연동에 실패했습니다."));
+		}
+		return ResponseEntity.ok(ApiResponse.success("거래 내역 조회에 성공했습니다.", walletId));
 	}
 }

--- a/src/main/java/com/kanghwang/khholdings/domain/my/MyController.java
+++ b/src/main/java/com/kanghwang/khholdings/domain/my/MyController.java
@@ -12,9 +12,9 @@ import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.kanghwang.khholdings.domain.my.dto.HoldingDTO;
-import com.kanghwang.khholdings.domain.my.dto.TransactionHistDTO;
 import com.kanghwang.khholdings.domain.my.dto.TxHistsSearchDTO;
 import com.kanghwang.khholdings.domain.my.dto.WalletDTO;
+import com.kanghwang.khholdings.domain.order.dto.TransactionRequestDTO;
 import com.kanghwang.khholdings.global.dto.ApiResponse;
 
 @RestController
@@ -48,8 +48,8 @@ public class MyController {
 
 	// 나의 거래 내역 조회(필터 조회, 기간 조회, 페이징)
 	@GetMapping("/transaction")
-	public ResponseEntity<ApiResponse<List<TransactionHistDTO>>> selectTxHistByWalletId(@ModelAttribute TxHistsSearchDTO searchDTO){
-		List<TransactionHistDTO> list = myService.selectTxHistByWalletId(searchDTO);
+	public ResponseEntity<ApiResponse<List<TransactionRequestDTO>>> selectTxHistByWalletId(@ModelAttribute TxHistsSearchDTO searchDTO){
+		List<TransactionRequestDTO> list = myService.selectTxHistByWalletId(searchDTO);
 
 		if (list == null || list.isEmpty()) {
 			return ResponseEntity.badRequest().body(ApiResponse.error("거래 내역 조회에 실패했습니다."));

--- a/src/main/java/com/kanghwang/khholdings/domain/my/MyController.java
+++ b/src/main/java/com/kanghwang/khholdings/domain/my/MyController.java
@@ -65,6 +65,6 @@ public class MyController {
 		if (walletId == null) {
 			return ResponseEntity.badRequest().body(ApiResponse.error("계좌 연동에 실패했습니다."));
 		}
-		return ResponseEntity.ok(ApiResponse.success("거래 내역 조회에 성공했습니다.", walletId));
+		return ResponseEntity.ok(ApiResponse.success("계좌 연동에 성공했습니다.", walletId));
 	}
 }

--- a/src/main/java/com/kanghwang/khholdings/domain/project/ProjectController.java
+++ b/src/main/java/com/kanghwang/khholdings/domain/project/ProjectController.java
@@ -2,14 +2,20 @@
 
  import java.math.BigDecimal;
  import java.util.List;
- import java.util.Map;
 
- import com.kanghwang.khholdings.domain.project.dto.SnapshotDTO;
  import org.springframework.beans.factory.annotation.Autowired;
  import org.springframework.http.ResponseEntity;
- import org.springframework.web.bind.annotation.*;
+ import org.springframework.web.bind.annotation.PathVariable;
+ import org.springframework.web.bind.annotation.PostMapping;
+ import org.springframework.web.bind.annotation.RequestBody;
+ import org.springframework.web.bind.annotation.RequestMapping;
+ import org.springframework.web.bind.annotation.RequestParam;
+ import org.springframework.web.bind.annotation.RestController;
 
- import com.kanghwang.khholdings.domain.project.dto.DividendDTO;
+ import com.kanghwang.khholdings.domain.project.dto.DividendRequestDTO;
+ import com.kanghwang.khholdings.domain.project.dto.SnapshotDTO;
+ import com.kanghwang.khholdings.domain.project.dto.SubscriptionRequestDTO;
+ import com.kanghwang.khholdings.global.dto.ApiResponse;
 
  @RestController
  @RequestMapping("/api/project")
@@ -20,90 +26,81 @@
 
  	// 청약 신청
  	@PostMapping("/application/{tokenId}")
- 	public ResponseEntity<?> applySubscription(@PathVariable Long tokenId,
+ 	public ResponseEntity<ApiResponse<Long>> applySubscription(@PathVariable Long tokenId,
  											   @RequestParam Long subscriptionId,
  											   @RequestParam Long walletId,
  											   @RequestParam BigDecimal amount) {
 
  		try {
  			Long txHistId = projectService.applySubscription(tokenId, subscriptionId, walletId, amount);
- 			return ResponseEntity.ok(Map.of(
- 				"transactionId", txHistId,
- 				"message", "청약 신청이 완료되었습니다."
- 			));
+ 			return ResponseEntity.ok(ApiResponse.success("청약 신청이 완료되었습니다.", txHistId));
  		} catch (RuntimeException e) {
- 			// "청약 신청에 실패했습니다."
- 			return ResponseEntity.badRequest().body(Map.of(
- 				"message", e.getMessage()
- 			));
+ 			return ResponseEntity.badRequest().body(ApiResponse.error("청약 신청에 실패했습니다."));
  		}
  	}
 
  	// 청약 취소
  	@PostMapping("/cancel/{transactionId}")
- 	public ResponseEntity<?> cancelSubscription(@PathVariable Long transactionId) {
+ 	public ResponseEntity<ApiResponse<Void>> cancelSubscription(@PathVariable Long transactionId) {
 
  		boolean isCancelled = projectService.cancelSubscription(transactionId);
 
  		if (isCancelled) {
- 			return ResponseEntity.ok("청약 취소가 완료되었습니다.");
+ 			return ResponseEntity.ok(ApiResponse.error("청약 취소가 완료되었습니다."));
  		} else {
- 			return ResponseEntity.badRequest().body("청약 취소에 실패했습니다.");
+ 			return ResponseEntity.badRequest().body(ApiResponse.error("청약 취소에 실패했습니다."));
  		}
 
  	}
 
  	// 청약 정산 (당첨, 낙첨)
- 	@PostMapping("/result/{transactionId}")
- 	public ResponseEntity<?> resultSubscription(@PathVariable Long transactionId,
- 												@RequestParam Long tokenId,
- 												@RequestParam Long passPrice,
- 												@RequestParam Long passVolume) {
+ 	@PostMapping("/result/{tokenId}")
+ 	public ResponseEntity<ApiResponse<Void>> resultSubscription(@PathVariable Long tokenId, @RequestBody List<SubscriptionRequestDTO> subRequestList) {
 
- 		boolean isCompleted = projectService.resultSubscription(transactionId, tokenId, passPrice, passVolume);
+ 		boolean isCompleted = projectService.resultSubscription(tokenId, subRequestList);
 
  		if (isCompleted) {
- 			return ResponseEntity.ok("청약 정산이 완료되었습니다.");
+ 			return ResponseEntity.ok(ApiResponse.error("청약 정산이 완료되었습니다."));
  		} else {
- 			return ResponseEntity.badRequest().body("청약 정산에 실패했습니다.");
+ 			return ResponseEntity.badRequest().body(ApiResponse.error("청약 정산에 실패했습니다."));
  		}
  	}
 
  	// 배당 스냅샷
  	@PostMapping("/dividend/before/{tokenId}")
- 	public ResponseEntity<?> resultSnapshot(@PathVariable Long tokenId) {
+ 	public ResponseEntity<ApiResponse<List<SnapshotDTO>>> resultSnapshot(@PathVariable Long tokenId) {
 
  		List<SnapshotDTO> list = projectService.resultSnapshot(tokenId);
 
- 		if (list.isEmpty()) {
- 			return ResponseEntity.badRequest().body("배당 스냅샷 실패했습니다.");
+ 		if (list == null || list.isEmpty()) {
+ 			return ResponseEntity.badRequest().body(ApiResponse.error("배당 스냅샷에 실패했습니다."));
  		}
-		return ResponseEntity.ok(list);
+		return ResponseEntity.ok(ApiResponse.success("배당 스냅샷이 완료되었습니다.", list));
  	}
 
  	// 배당 정산
- 	@PostMapping("/dividend/after/{walletId}")
- 	public ResponseEntity<?> resultDividend(@RequestBody List<DividendDTO> divList) {
+ 	@PostMapping("/dividend/after/{tokenId}")
+ 	public ResponseEntity<ApiResponse<Void>> resultDividend(@PathVariable Long tokenId, @RequestBody List<DividendRequestDTO> divRequestList) {
 
- 		boolean isCompleted = projectService.resultDividend(divList);
+ 		boolean isCompleted = projectService.resultDividend(tokenId, divRequestList);
 
  		if (isCompleted) {
- 			return ResponseEntity.ok("배당 정산이 완료되었습니다.");
+ 			return ResponseEntity.ok(ApiResponse.error("배당 정산이 완료되었습니다."));
  		} else {
- 			return ResponseEntity.badRequest().body("배당 정산에 실패했습니다.");
+ 			return ResponseEntity.badRequest().body(ApiResponse.error("배당 정산에 실패했습니다."));
  		}
  	}
 
  	// 토큰 소각
  	@PostMapping("/close/{tokenId}")
- 	public ResponseEntity<?> burnToken(@PathVariable Long tokenId) {
+ 	public ResponseEntity<ApiResponse<Void>> burnToken(@PathVariable Long tokenId) {
 
  		boolean isCompleted = projectService.burnToken(tokenId);
 
  		if (isCompleted) {
- 			return ResponseEntity.ok("토큰 소각 및 정산이 완료되었습니다.");
+ 			return ResponseEntity.ok(ApiResponse.error("토큰 소각 및 정산이 완료되었습니다."));
  		} else {
- 			return ResponseEntity.badRequest().body("토큰 소각에 실패했습니다.");
+ 			return ResponseEntity.badRequest().body(ApiResponse.error("토큰 소각에 실패했습니다."));
  		}
  	}
  }

--- a/src/main/java/com/kanghwang/khholdings/domain/project/ProjectRepository.java
+++ b/src/main/java/com/kanghwang/khholdings/domain/project/ProjectRepository.java
@@ -4,11 +4,12 @@ import java.math.BigDecimal;
 import java.util.List;
 import java.util.Map;
 
-import com.kanghwang.khholdings.domain.project.dto.BurnDTO;
-import com.kanghwang.khholdings.domain.project.dto.SnapshotDTO;
 import org.apache.ibatis.annotations.Mapper;
 
+import com.kanghwang.khholdings.domain.project.dto.BurnDTO;
 import com.kanghwang.khholdings.domain.project.dto.DividendDTO;
+import com.kanghwang.khholdings.domain.project.dto.SnapshotDTO;
+import com.kanghwang.khholdings.domain.project.dto.SubscriptionDTO;
 
 @Mapper
 public interface ProjectRepository {
@@ -20,7 +21,7 @@ public interface ProjectRepository {
 	boolean cancelSubscription(Long transactionId, Long newTransactionId, String hashValue);
 
 	// 청약 정산 (당첨, 낙첨)
-	boolean resultSubscription(Long transactionId, Long tokenId, Long passTransactionId, Long failTransactionId, Long passPrice, Long passVolume, String passHashValue, String failHashValue);
+	boolean resultSubscription(List<SubscriptionDTO> subscriptionDTOList);
 
 	// 배당 스냅샷 (반환용)
 	List<SnapshotDTO> resultSnapshot(Long tokenId);

--- a/src/main/java/com/kanghwang/khholdings/domain/project/ProjectService.java
+++ b/src/main/java/com/kanghwang/khholdings/domain/project/ProjectService.java
@@ -5,17 +5,20 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
-import com.kanghwang.khholdings.domain.market.MarketRepository;
-import com.kanghwang.khholdings.domain.project.dto.BurnDTO;
-import com.kanghwang.khholdings.domain.project.dto.SnapshotDTO;
-import lombok.RequiredArgsConstructor;
 import org.apache.commons.codec.digest.DigestUtils;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import com.kanghwang.khholdings.domain.market.MarketRepository;
+import com.kanghwang.khholdings.domain.project.dto.BurnDTO;
 import com.kanghwang.khholdings.domain.project.dto.DividendDTO;
+import com.kanghwang.khholdings.domain.project.dto.DividendRequestDTO;
+import com.kanghwang.khholdings.domain.project.dto.SnapshotDTO;
+import com.kanghwang.khholdings.domain.project.dto.SubscriptionDTO;
+import com.kanghwang.khholdings.domain.project.dto.SubscriptionRequestDTO;
 import com.kanghwang.khholdings.global.util.SnowflakeIdGenerator;
+
+import lombok.RequiredArgsConstructor;
 
 @Service
 @RequiredArgsConstructor
@@ -60,21 +63,54 @@ public class ProjectService {
 
 	// 청약 정산 (당첨, 낙첨)
 	@Transactional
-	public boolean resultSubscription(Long transactionId, Long tokenId, Long passPrice, Long passVolume) {
+	public boolean resultSubscription(Long tokenId, List<SubscriptionRequestDTO> subRequestList) {
 
-		// 1. Snowflake ID 생성
-		Long passTxId = SnowflakeIdGenerator.nextId();
-		Long failTxId = SnowflakeIdGenerator.nextId();
+		if (subRequestList == null || subRequestList.size() == 0) {
+			return false;
+		}
 
-		// 2. 해시값 생성
-		String passHashValue = DigestUtils.sha256Hex(transactionId.toString());
-		String failHashValue = DigestUtils.sha256Hex(transactionId.toString());
+		int BATCH_SIZE = 1000;
+		List<SubscriptionDTO> batchBuffer = new ArrayList<>();
 
-		return projectRepository.resultSubscription(transactionId, tokenId, passTxId, failTxId, passPrice, passVolume,
-				passHashValue, failHashValue);
+		for (SubscriptionRequestDTO subRequestDTO : subRequestList) {
+
+			// 1. Snowflake ID 생성
+			Long passTxId = SnowflakeIdGenerator.nextId();
+			Long failTxId = SnowflakeIdGenerator.nextId();
+
+			// 2. 해시값 생성
+			String passHashValue = DigestUtils.sha256Hex(passTxId.toString());
+			String failHashValue = DigestUtils.sha256Hex(failTxId.toString());
+
+			// 3. 요청 객체 생성
+			SubscriptionDTO subscriptionDTO = SubscriptionDTO.builder()
+				.passTxId(passTxId)
+				.failTxId(failTxId)
+				.subscriptionId(subRequestDTO.getSubscriptionId())
+				.tokenId(tokenId)
+				.walletId(subRequestDTO.getWalletId())
+				.passPrice(subRequestDTO.getPassPrice())
+				.passVolume(subRequestDTO.getPassVolume())
+				.passHashValue(passHashValue)
+				.failHashValue(failHashValue)
+				.build();
+
+			batchBuffer.add(subscriptionDTO);
+
+			if (batchBuffer.size() >= BATCH_SIZE) {
+				projectRepository.resultSubscription(batchBuffer);
+				batchBuffer.clear();
+			}
+		}
+
+		if (!batchBuffer.isEmpty()) {
+			projectRepository.resultSubscription(batchBuffer);
+		}
+
+		return true;
 	}
 
-	// 배당 스앱샷
+	// 배당 스냅샷
 	@Transactional
 	public List<SnapshotDTO> resultSnapshot(Long tokenId) {
 
@@ -89,21 +125,29 @@ public class ProjectService {
 
 	// 배당 정산
 	@Transactional
-	public boolean resultDividend(List<DividendDTO> divList) {
+	public boolean resultDividend(Long tokenId, List<DividendRequestDTO> divRequestList) {
 
-		if (divList == null || divList.size() == 0) {
+		if (divRequestList == null || divRequestList.size() == 0) {
 			return false;
 		}
 
 		int BATCH_SIZE = 1000;
 		List<DividendDTO> batchBuffer = new ArrayList<>();
 
-		for (DividendDTO dividendDTO : divList) {
+		for (DividendRequestDTO dividendRequestDTO : divRequestList) {
 
 			Long transactionId = SnowflakeIdGenerator.nextId();
+			String hashValue = DigestUtils.sha256Hex(transactionId.toString());
 
-			dividendDTO.setTransactionId(transactionId);
-			dividendDTO.setHashValue(transactionId.toString() + transactionId.toString());
+			DividendDTO dividendDTO = DividendDTO.builder()
+				.transactionId(transactionId)
+				.dividendId(dividendRequestDTO.getDividendId())
+				.tokenId(tokenId)
+				.walletId(dividendRequestDTO.getWalletId())
+				.amount(dividendRequestDTO.getBeforeTaxAmount())
+				.fee(dividendRequestDTO.getBeforeTaxAmount().subtract(dividendRequestDTO.getAfterTaxAmount()))
+				.hashValue(hashValue)
+				.build();
 
 			batchBuffer.add(dividendDTO);
 
@@ -136,8 +180,8 @@ public class ProjectService {
 		}
 
 		// 1. 단가 조회
-		BigDecimal tradePrice = marketRepository.selectLatestTokenPrice(tokenId);
-		if (tradePrice == null) {
+		BigDecimal currentPrice = marketRepository.selectLatestTokenPrice(tokenId);
+		if (currentPrice == null) {
 			throw new RuntimeException("현재 시세를 찾을 수 없습니다.");
 		}
 
@@ -153,19 +197,19 @@ public class ProjectService {
 
 		for (SnapshotDTO holder : holders) {
 
-			BigDecimal tokenBalance = holder.getTokenBalance();
-			BigDecimal calcCash = tokenBalance.multiply(tradePrice);
+			BigDecimal amount = holder.getTotalBalance();          // 토큰 보유 수량
+			BigDecimal cashAmount = amount.multiply(currentPrice); // 시세를 기준으로 환전
 
 			Long txId1 = SnowflakeIdGenerator.nextId();
 			Long txId2 = SnowflakeIdGenerator.nextId();
 
 			BurnDTO burnDTO = BurnDTO.builder()
-				.walletId(holder.getWalletId())
-				.tokenId(holder.getTokenId())
 				.txId1(txId1)
 				.txId2(txId2)
-				.amount(tokenBalance)
-				.cashAmount(calcCash)
+				.tokenId(holder.getTokenId())
+				.walletId(holder.getWalletId())
+				.amount(amount)
+				.cashAmount(cashAmount)
 				.hashValue1(DigestUtils.sha256Hex(txId1.toString()))
 				.hashValue2(DigestUtils.sha256Hex(txId2.toString()))
 				.build();

--- a/src/main/java/com/kanghwang/khholdings/domain/project/dto/DividendDTO.java
+++ b/src/main/java/com/kanghwang/khholdings/domain/project/dto/DividendDTO.java
@@ -12,8 +12,9 @@ import lombok.*;
 public class DividendDTO {
 	private Long transactionId;
 	private Long dividendId;
+	private Long tokenId;
 	private Long walletId;
-	private BigDecimal amount;
-	private BigDecimal fee;
+	private BigDecimal amount; // 세전 배당금
+	private BigDecimal fee;    // 세후 배당금 - 세전 배당금
 	private String hashValue;
 }

--- a/src/main/java/com/kanghwang/khholdings/domain/project/dto/DividendRequestDTO.java
+++ b/src/main/java/com/kanghwang/khholdings/domain/project/dto/DividendRequestDTO.java
@@ -13,9 +13,9 @@ import lombok.Setter;
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor
-public class SnapshotDTO {
-    private Long userId;				// 유저 아이디
-    private Long walletId;			    // 지갑 번호
-    private Long tokenId;		        // 토큰 번호
-    private BigDecimal totalBalance;    // 토큰 보유 수량
+public class DividendRequestDTO {
+	private Long dividendId;
+	private Long walletId;
+	private BigDecimal beforeTaxAmount; // 세전 배당금
+	private BigDecimal afterTaxAmount;  // 새후 배당금
 }

--- a/src/main/java/com/kanghwang/khholdings/domain/project/dto/SubscriptionDTO.java
+++ b/src/main/java/com/kanghwang/khholdings/domain/project/dto/SubscriptionDTO.java
@@ -1,0 +1,24 @@
+package com.kanghwang.khholdings.domain.project.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class SubscriptionDTO {
+	private Long passTxId;
+	private Long failTxId;
+	private Long subscriptionId;
+	private Long tokenId;
+	private Long walletId;
+	private Long passPrice;  // 당첨 가격
+	private Long passVolume; // 당첨 수량
+	private String passHashValue;
+	private String failHashValue;
+}

--- a/src/main/java/com/kanghwang/khholdings/domain/project/dto/SubscriptionRequestDTO.java
+++ b/src/main/java/com/kanghwang/khholdings/domain/project/dto/SubscriptionRequestDTO.java
@@ -1,0 +1,19 @@
+package com.kanghwang.khholdings.domain.project.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class SubscriptionRequestDTO {
+	private Long subscriptionId;
+	private Long walletId;
+	private Long passPrice;  // 당첨 가격
+	private Long passVolume; // 당첨 수량
+}

--- a/src/main/java/com/kanghwang/khholdings/global/dto/ApiResponse.java
+++ b/src/main/java/com/kanghwang/khholdings/global/dto/ApiResponse.java
@@ -1,0 +1,23 @@
+package com.kanghwang.khholdings.global.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+@AllArgsConstructor
+public class ApiResponse<T> {
+	private String message;
+	private T payload;
+
+	// 데이터 없이 메시지만 보내는 응답
+	public static <T> ApiResponse<T> error(String message) {
+		return new ApiResponse<>(message, null);
+	}
+
+	// 데이터를 포함한 응답
+	public static <T> ApiResponse<T> success(String message, T data) {
+		return new ApiResponse<>(message, data);
+	}
+}

--- a/src/main/resources/mapper/MarketMapper.xml
+++ b/src/main/resources/mapper/MarketMapper.xml
@@ -71,7 +71,7 @@
 
     <select id="selectLatestTokenPrice">
         SELECT
-            trade_price
+            closing_price
         FROM
             token_quotes
         WHERE

--- a/src/main/resources/mapper/ProjectMapper.xml
+++ b/src/main/resources/mapper/ProjectMapper.xml
@@ -21,7 +21,7 @@
         )
         SELECT
             #{transactionId}, #{subscriptionId}, NULL, #{walletId},
-            'SUBSCRIPTION', 'CASH', 'OUT', #{amount},
+            'SUBSCRIPTION'::transaction_type_enum, 'CASH', 'OUT', #{amount},
             uw.cash_balance, 0, 0,
             NOW(), 0, #{hashValue}
         FROM updated_wallet uw
@@ -34,7 +34,7 @@
             SELECT wallet_id, amount, trade_id
             FROM transaction_hists
             WHERE transaction_id = #{transactionId}
-              AND transaction_type = 'SUBSCRIPTION' -- 해당 내역이 청약 건인지 추가 검증
+              AND transaction_type = 'SUBSCRIPTION'::transaction_type_enum -- 해당 내역이 청약 건인지 추가 검증
         ),
         update_wallet AS (
             -- 2. 지갑 잔액 환불
@@ -60,64 +60,72 @@
     </insert>
 
     <insert id="resultSubscription">
-        /* 1. 청약 신청 정보 및 결과(당첨, 낙첨) 금액 계산 */
-        WITH result AS (
+        <foreach collection="list" item="item" separator=";">
+            -- 1. 청약 신청 정보 및 금액 계산
+            WITH result AS (
             SELECT
-                wallet_id, trade_id, amount as total_amount,
-                #{passVolume} as pass_volume,
-                (#{passPrice} * #{passVolume}) as pass_amount,
-                (amount - (#{passPrice} * #{passVolume})) as fail_amount
+                wallet_id,
+                trade_id,
+                amount as total_amount,
+                #{item.passVolume} as pass_volume,
+                (#{item.passPrice} * #{item.passVolume}) as pass_amount,
+                (amount - (#{item.passPrice} * #{item.passVolume})) as fail_amount
             FROM transaction_hists
-            WHERE transaction_id = #{transactionId}
-            AND transaction_type = 'SUBSCRIPTION'
-        ),
-        /* 2. 지갑 잔액 환불 (FAIL) */
-        update_wallet AS (
+            WHERE trade_id = #{item.subscriptionId}
+            AND wallet_id = #{item.walletId}
+            AND transaction_type = 'SUBSCRIPTION'::transaction_type_enum
+            LIMIT 1
+            ),
+            -- 2. 지갑 잔액 환불, FAIL 금액 발생 시만
+            update_wallet AS (
             UPDATE wallets w
-            SET cash_balance = w.cash_balance + r.fail_amount,
+            SET
+                cash_balance = w.cash_balance + r.fail_amount,
                 updated_at = NOW()
-                FROM result r
-            WHERE w.wallet_id = r.wallet_id AND r.fail_amount > 0
+            FROM result r
+            WHERE w.wallet_id = r.wallet_id
+                AND r.fail_amount > 0
             RETURNING w.wallet_id, w.cash_balance
-        ),
-        /* 3. 보유 토큰에 추가 (PASS) */
-        insert_holdings AS (
+            ),
+            -- 3. 토큰 보유 기록 추가, PASS 수량 발생 시만
+            insert_holdings AS (
             INSERT INTO holdings (
                 wallet_id, token_id, token_balance, reserved,
                 purchased_value, created_at
             )
             SELECT
-                r.wallet_id, #{tokenId}, r.pass_volume, 0,
+                r.wallet_id, #{item.tokenId}, r.pass_volume, 0,
                 r.pass_amount, NOW()
             FROM result r
             WHERE r.pass_volume > 0
             RETURNING wallet_id, token_balance
-        )
-        /* 4. 거래 내역 기록 (PASS / FAIL) */
-        INSERT INTO transaction_hists (
-            transaction_id, trade_id, wallet_id, transaction_type,
-            asset_type, direction, amount, balance_after,
-            remaining_price, remaining_volume, created_at, fee, hash_value
-        )
-        -- 1) 당첨 내역 (PASS)
-        SELECT
-            #{passTransactionId}, r.trade_id, r.wallet_id, 'PASS'::transaction_type_enum,
-            'TOKEN'::asset_type_enum, 'IN'::direction_enum, r.pass_volume, ih.token_balance,
-            0, 0, NOW(), 0, #{passHashValue}
-        FROM result r
-             INNER JOIN insert_holdings ih ON r.wallet_id = ih.wallet_id
-        WHERE r.pass_volume > 0
+            )
+            -- 4. 최종 거래 내역 기록
+            INSERT INTO transaction_hists (
+                transaction_id, trade_id, wallet_id, transaction_type,
+                asset_type, direction, amount, balance_after,
+                remaining_price, remaining_volume, created_at, fee, hash_value
+            )
+            -- 4.1 당첨 내역, PASS
+            SELECT
+                #{item.passTxId}, r.trade_id, r.wallet_id, 'PASS'::transaction_type_enum,
+                'TOKEN'::asset_type_enum, 'IN'::direction_enum, r.pass_volume, ih.token_balance,
+                0, 0, NOW(), 0, #{item.passHashValue}
+            FROM result r
+            INNER JOIN insert_holdings ih ON r.wallet_id = ih.wallet_id
+            WHERE r.pass_volume > 0
 
-        UNION ALL
+            UNION ALL
 
-        -- 2) 환불 내역 (FAIL)
-        SELECT
-            #{failTransactionId}, r.trade_id, r.wallet_id, 'FAIL'::transaction_type_enum,
-            'CASH'::asset_type_enum, 'IN'::direction_enum, r.fail_amount, uw.cash_balance,
-            0, 0, NOW(), 0, #{failHashValue}
-        FROM result r
-             INNER JOIN update_wallet uw ON r.wallet_id = uw.wallet_id
-        WHERE r.fail_amount > 0;
+            -- 4.2 환불 내역, FAIL
+            SELECT
+                #{item.failTxId}, r.trade_id, r.wallet_id, 'FAIL'::transaction_type_enum,
+                'CASH'::asset_type_enum, 'IN'::direction_enum, r.fail_amount, uw.cash_balance,
+                0, 0, NOW(), 0, #{item.failHashValue}
+            FROM result r
+            INNER JOIN update_wallet uw ON r.wallet_id = uw.wallet_id
+            WHERE r.fail_amount > 0
+        </foreach>
     </insert>
 
     <select id="resultSnapshot" resultType="SnapshotDTO">
@@ -126,12 +134,12 @@
             u.user_id,
             w.wallet_id,
             h.token_id,
-            h.token_balance
+            h.token_balance + h.reserved as total_balance
         FROM holdings h
-        JOIN wallets w ON h.wallet_id = w.wallet_id
-        JOIN users u ON w.user_id = u.user_id
-        --WHERE h.token_balance > 0
-        AND h.token_id = #{tokenId}
+            JOIN wallets w ON h.wallet_id = w.wallet_id
+            JOIN users u ON w.user_id = u.user_id
+        WHERE h.token_balance + h.reserved > 0
+            AND h.token_id = #{tokenId}
     </select>
 
     <insert id="insertSnapshot">
@@ -145,22 +153,22 @@
             (
             #{item.tokenId},
             #{item.walletId},
-            #{item.tokenBalance}
+            #{item.totalBalance}
             )
         </foreach>
     </insert>
 
     <update id="resultDividend" parameterType="java.util.List">
         <foreach collection="list" item="item" separator=";">
-            -- 배당금 입급
+            -- 1. 배당금 입급
             WITH updated_wallet AS (
                 UPDATE wallets
-                SET cash_balance = cash_balance + #{item.amount} -#{item.fee},
+                SET cash_balance = cash_balance + #{item.amount} - #{item.fee},
                     updated_at = NOW()
                 WHERE wallet_id = #{item.walletId}
                 RETURNING cash_balance
             )
-            -- 배당 내역 삽입
+            -- 2. 배당 내역 삽입
             INSERT INTO transaction_hists (
                 transaction_id,
                 trade_id,
@@ -185,18 +193,26 @@
                 #{item.hashValue},
                 #{item.fee}
             FROM
-                updated_wallet uw
+                updated_wallet uw;
+            -- 3. 스냅샷 테이블 업데이트
+            UPDATE dividend_hists
+            SET
+                transaction_id = #{item.transactionId},
+                dividend_amount = #{item.amount} - #{item.fee},
+                updated_at = NOW()
+            WHERE token_id = #{item.tokenId}
+            AND wallet_id = #{item.walletId}
         </foreach>
     </update>
 
     <update id="burnTokenBatch" parameterType="java.util.List">
         -- 토큰 소각
-        WITH updates(wallet_id, token_id, sold_volume, cash_amount, tx_id1, tx_id2, h_val1, h_val2) AS (
+        WITH updates(wallet_id, token_id, amount, cash_amount, tx_id1, tx_id2, h_val1, h_val2) AS (
             VALUES
             <foreach collection="list" item="item" separator=",">
                 (
-                 #{item.walletId}::bigint,
-                 #{item.tokenId}::bigint,
+                #{item.walletId}::bigint,
+                #{item.tokenId}::bigint,
                 #{item.amount}::numeric,
                 #{item.cashAmount}::numeric,
                 #{item.txId1}::bigint,
@@ -210,7 +226,8 @@
             -- 2. 토큰 잔액 차감 및 차감 전 보유량 반환
             UPDATE holdings h
             SET
-                token_balance = h.token_balance - u.sold_volume,
+                token_balance = 0,
+                reserved = 0,
                 purchased_value = 0,
                 updated_at = now()
             FROM
@@ -227,7 +244,7 @@
                 updated_at = now()
             FROM updates u
             WHERE w.wallet_id = u.wallet_id
-            RETURNING w.wallet_id, w.cash_balance as balance_after, u.token_id as orign_token_id
+            RETURNING w.wallet_id, w.cash_balance as balance_after, u.token_id
         )
         INSERT INTO transaction_hists (
             transaction_id,
@@ -249,11 +266,11 @@
             v.t_hash,
             v.t_asset
         FROM updates u
-        JOIN update_wallet uw ON u.wallet_id = uw.wallet_id AND u.token_id = uw.orign_token_id
+        JOIN update_wallet uw ON u.wallet_id = uw.wallet_id AND u.token_id = uw.token_id
         JOIN deduct_holdings dh ON u.wallet_id = dh.wallet_id AND u.token_id = dh.token_id
         CROSS JOIN LATERAL (
         VALUES
-            (u.tx_id1, 'OUT'::direction_enum, u.sold_volume, 0, u.h_val1, 'TOKEN'::asset_type_enum),
+            (u.tx_id1, 'OUT'::direction_enum, u.amount, 0, u.h_val1, 'TOKEN'::asset_type_enum),
             (u.tx_id2, 'IN'::direction_enum,  u.cash_amount, uw.balance_after, u.h_val2, 'CASH'::asset_type_enum)
         ) AS v(tx_id, t_dir, t_amt, t_bal, t_hash, t_asset)
     </update>

--- a/src/main/resources/mapper/ProjectMapper.xml
+++ b/src/main/resources/mapper/ProjectMapper.xml
@@ -134,11 +134,11 @@
             u.user_id,
             w.wallet_id,
             h.token_id,
-            h.token_balance + h.reserved as total_balance
+            h.token_balance as total_balance
         FROM holdings h
             JOIN wallets w ON h.wallet_id = w.wallet_id
             JOIN users u ON w.user_id = u.user_id
-        WHERE h.token_balance + h.reserved > 0
+        WHERE h.token_balance > 0
             AND h.token_id = #{tokenId}
     </select>
 


### PR DESCRIPTION
## 📌 작업 내용 요약 (Summary)
- 배치를 사용하여 청약 정산을 한 번에 처리할 수 있도록 수정
- 배당 스냅샷 찍을 때, 잠긴 토큰까지 계산
- ApiResponse라는 공통 응답 DTO를 만들어 Carbon, Market, My, Project에 적용
- 토큰 시가 조회 시, trade_price (거래 대금) -> closing_price (종가)로 수정

## 📝 변경 사항 (Key Changes)
- [ ] ProjectService - 청약 정산 로직
- [ ] ProjectMapper - 배당 스냅샷 로직
- [ ] 각 Controller 응답 형태
- [ ] MarketMapper - 토큰 시가 조회

## 📸 스크린샷 (Screenshots / Demos)
| Feature | Screenshot |
| :--- | :--- |
| 기능명 | 사진첨부 |

## 🔗 연관된 이슈 (Related Issues)
- Close #

## 🧐 주요 리뷰 포인트 (Review Point)
- 

## ✅ 최종 PR전 체크 리스트 (Checklist)
- [ ] 코딩 컨벤션(Checkstyle)을 준수하였는가?
- [ ] 불필요한 주석이나 시스템 로그(console.log, print)를 제거하였는가?
- [ ] 변경 사항에 대한 테스트를 완료하였는가?
- [ ] 관련 문서를 업데이트하였는가?
