### PR TITLE
[FEAT] 1분봉 저장 및 웹소켓 구현

### DIFF
--- a/src/main/java/com/kanghwang/khholdings/domain/market/MarketWorker.java
+++ b/src/main/java/com/kanghwang/khholdings/domain/market/MarketWorker.java
@@ -1,5 +1,6 @@
 package com.kanghwang.khholdings.domain.market;
 
+import com.kanghwang.khholdings.domain.order.dto.CandleDTO;
 import org.redisson.api.RPatternTopic;
 import org.redisson.api.RedissonClient;
 import org.redisson.codec.JsonJacksonCodec;
@@ -22,15 +23,13 @@ public class MarketWorker {
 
 	private final RedissonClient redissonClient;
 	private final SimpMessagingTemplate messagingTemplate;
-
-	@PostConstruct
-	public void listenTradeTopic() {
-
-		// Jackson이 OffsetDateTime을 읽을 있도록 JavaTimeModule 등록
-		ObjectMapper objectMapper = new ObjectMapper()
+	// Jackson이 OffsetDateTime을 읽을 있도록 JavaTimeModule 등록
+	private final ObjectMapper objectMapper = new ObjectMapper()
 			.registerModule(new JavaTimeModule()) // Java 8 날짜 타입 지원 추가
 			.disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
 
+	@PostConstruct
+	public void listenTradeTopic() {
 		// [체결]
 		// 1. Redis Topic 구독 (패턴 매칭 사용: 모든 토큰의 체결을 감시)
 		// JsonJacksonCodec을 사용하여 브라우저가 읽을 수 있는 JSON 형태로 받기
@@ -70,6 +69,16 @@ public class MarketWorker {
 			} else {
 				System.out.println("[MarketWorker] WebSocket 주문 삭제: OrderID " + data);
 			}
+		});
+
+		// [차트]
+		RPatternTopic candleTopic = redissonClient.getPatternTopic("candle:topic:*", new JsonJacksonCodec(objectMapper));
+
+		// 리스너 타입을 candleDTO로 명시
+		candleTopic.addListener(CandleDTO.class, (pattern, channel, msg) -> {
+			String tokenId = channel.toString().split(":")[2];
+
+			messagingTemplate.convertAndSend("/topic/candles/" + tokenId, msg);
 		});
 	}
 }

--- a/src/main/java/com/kanghwang/khholdings/domain/my/dto/TransactionHistDTO.java
+++ b/src/main/java/com/kanghwang/khholdings/domain/my/dto/TransactionHistDTO.java
@@ -11,13 +11,22 @@ import java.time.OffsetDateTime;
 @NoArgsConstructor
 @AllArgsConstructor
 public class TransactionHistDTO {
-    private OffsetDateTime createdAt;           // 거래 일시
-    private String transactionType;             // 구분 [TODO] enum 타입 지정
-    private String tokenName;                   // 토큰명
-    private Long tickerSymbol;                  // 종목 코드
-    private BigDecimal unitPrice;               // 체결 단가
-    private BigDecimal transactionVolume;       // 토큰 거래 수량
-    private BigDecimal tokenBalanceAfter;       // 토큰 거래 후 수량
-    private BigDecimal transactionAmount;       // 거래 금액
-    private BigDecimal balanceAfter;            // 거래 후 잔액
+    private Long transactionId;                 // 체결 내역 번호
+    private Long tradeId;                       // 거래 번호
+    private Long orderId;                       // 주문 번호
+    private Long walletId;                      // 지갑 번호
+
+    private String transactionType;             // "TRADE" 고정
+    private String assetType;                   // "CASH" 또는 "TOKEN"
+    private String direction;                   // "IN" 또는 "OUT"
+
+    private BigDecimal amount;                  // 이번에 움직인 수량/금액
+    private BigDecimal balanceAfter;            // 이거 처리하고 남은 최종 잔액
+    private BigDecimal remainingVolume;         // 주문 후 남은 토큰 수량
+    private BigDecimal remainingPrice;          // 주문 후 남은 현금 금액
+    private BigDecimal fee;                     // 발생한 수수료
+
+    private String hashValue;                   // 데이터 위변조 방지용 해시
+    private OffsetDateTime createdAt;           // 체결 시각
+
 }

--- a/src/main/java/com/kanghwang/khholdings/domain/order/OrderRepository.java
+++ b/src/main/java/com/kanghwang/khholdings/domain/order/OrderRepository.java
@@ -1,24 +1,36 @@
 package com.kanghwang.khholdings.domain.order;
 
 import java.math.BigDecimal;
+import java.util.List;
+import java.util.Map;
 
+import com.kanghwang.khholdings.domain.my.dto.TransactionHistDTO;
+import com.kanghwang.khholdings.domain.order.dto.*;
 import org.apache.ibatis.annotations.Mapper;
 
-import com.kanghwang.khholdings.domain.order.dto.OrderRequestDTO;
-import com.kanghwang.khholdings.domain.order.dto.RefundRequestDTO;
-import com.kanghwang.khholdings.domain.order.dto.TransactionRequestDTO;
+import org.apache.ibatis.annotations.Param;
 
 @Mapper
 public interface OrderRepository {
 
+	// 특정 토큰 보유량 조회
 	BigDecimal selectHoldingTokenBalance(Long walletId, Long tokenId);
 
+	// 사용 가능한 잔액 조회
 	BigDecimal selectAvailableBalance(Long walletId);
 
+	// 주문
 	void callPlaceOrderProcedure(OrderRequestDTO orderDTO);
 
-	void p_process_transaction_hists(TransactionRequestDTO transactionDTO);
+	// 정산
+	void p_process_transaction_settlement(TransactionRequestDTO trade, SettlementResultDTO result);
 
+	// 환불
 	void p_cancel_order_and_refund(RefundRequestDTO refundDTO);
 
+	// 체결 내역 벌크 인서트
+    void bulkInsertTradeHistory(@Param("list") List<TransactionHistDTO> list);
+
+	// 1분봉 데이터 벌크 인서트
+	void insertCandlesBatch(@Param("list") List<CandleDTO> list);
 }

--- a/src/main/java/com/kanghwang/khholdings/domain/order/TradeWorker.java
+++ b/src/main/java/com/kanghwang/khholdings/domain/order/TradeWorker.java
@@ -39,6 +39,10 @@ public class TradeWorker implements CommandLineRunner {
     private final OrderRepository orderRepository;
     private volatile boolean isRunning = true;
     private final CountDownLatch shutdownLatch = new CountDownLatch(1); // 종료 확인을 위한 래치 (1개의 스레드가 끝날 때까지 대기)
+    private final ObjectMapper objectMapper = new ObjectMapper()
+            .registerModule(new JavaTimeModule())
+            .disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
+
 
     // 체결 내역 벌크 인서트를 위한 버퍼
     private final Queue<TransactionHistDTO> tradeBuffer = new ConcurrentLinkedQueue<>();
@@ -85,11 +89,6 @@ public class TradeWorker implements CommandLineRunner {
     }
 
     private void processStream() {
-
-        // Jackson이 OffsetDateTime을 읽을 있도록 JavaTimeModule 등록
-        ObjectMapper objectMapper = new ObjectMapper()
-                .registerModule(new JavaTimeModule()) // Java 8 날짜 타입 지원 추가
-                .disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
 
         RStream<String, Object> stream = redissonClient.getStream("trade:stream:", new JsonJacksonCodec(objectMapper));
         StreamMessageId lastId = StreamMessageId.ALL; // 처음부터 혹은 최신부터 읽기 설정 가능
@@ -183,6 +182,31 @@ public class TradeWorker implements CommandLineRunner {
                 List.of(candleKey),
                 trade.getTargetPrice().toPlainString(),
                 trade.getExecutedVolume().toPlainString());
+
+        // 업데이트된 최신 캔들 정보를 읽어서 전파
+        // 추후에 트레이딩뷰 차트를 실시간으로 움직이게 함
+        Map<String, String> candleMap = redissonClient
+                .<String, String>getMap(candleKey, org.redisson.client.codec.StringCodec.INSTANCE)
+                .readAllMap();
+
+        if (candleMap != null && !candleMap.isEmpty()) {
+            String topicKey = "candle:topic:" + trade.getTokenId();
+
+            // 시간은 프론트엔드에서 한국 시간으로 변경 예정
+            CandleDTO liveCandle = CandleDTO.builder()
+                    .tokenId(trade.getTokenId())
+                    .unit(1)
+                    .candleTime(OffsetDateTime.ofInstant(java.time.Instant.ofEpochSecond(minute), ZoneOffset.UTC))
+                    .openingPrice(new BigDecimal(candleMap.get("open")))
+                    .highPrice(new BigDecimal(candleMap.get("high")))
+                    .lowPrice(new BigDecimal(candleMap.get("low")))
+                    .closingPrice(new BigDecimal(candleMap.get("close")))
+                    .tradeVolume(new BigDecimal(candleMap.get("vol")))
+                    .build();
+
+            // DTO 자체를 Redis Topic으로 발행 (MarketWorker가 받음)
+            redissonClient.getTopic(topicKey, new JsonJacksonCodec(objectMapper)).publish(liveCandle);
+        }
     }
 
     // 매 분 5초에 실행

--- a/src/main/java/com/kanghwang/khholdings/domain/order/TradeWorker.java
+++ b/src/main/java/com/kanghwang/khholdings/domain/order/TradeWorker.java
@@ -1,22 +1,29 @@
 package com.kanghwang.khholdings.domain.order;
 
+import java.math.BigDecimal;
 import java.time.Duration;
-import java.util.Map;
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
+import java.time.temporal.ChronoUnit;
+import java.util.*;
+import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 
-import org.redisson.api.RStream;
-import org.redisson.api.RedissonClient;
-import org.redisson.api.StreamMessageId;
+import com.kanghwang.khholdings.domain.my.dto.TransactionHistDTO;
+import com.kanghwang.khholdings.domain.order.dto.CandleDTO;
+import org.redisson.api.*;
 import org.redisson.api.stream.StreamReadArgs;
 import org.redisson.codec.JsonJacksonCodec;
 import org.springframework.boot.CommandLineRunner;
+import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Service;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import com.kanghwang.khholdings.domain.order.dto.RefundRequestDTO;
+import com.kanghwang.khholdings.domain.order.dto.SettlementResultDTO;
 import com.kanghwang.khholdings.domain.order.dto.TransactionRequestDTO;
 
 import jakarta.annotation.PreDestroy;
@@ -33,12 +40,34 @@ public class TradeWorker implements CommandLineRunner {
     private volatile boolean isRunning = true;
     private final CountDownLatch shutdownLatch = new CountDownLatch(1); // 종료 확인을 위한 래치 (1개의 스레드가 끝날 때까지 대기)
 
+    // 체결 내역 벌크 인서트를 위한 버퍼
+    private final Queue<TransactionHistDTO> tradeBuffer = new ConcurrentLinkedQueue<>();
+
+    // 1분 봉 업데이트 용 Lua Script
+    private static final String luaScript = """
+            local c = redis.call('HMGET', KEYS[1], 'high', 'low', 'close', 'vol')
+            local price = tonumber(ARGV[1])
+            local vol = tonumber(ARGV[2])
+
+            if not c[1] then
+                -- 새 봉 생성
+                redis.call('HMSET', KEYS[1], 'open', price, 'high', price, 'low', price, 'close', price, 'vol', vol)
+            else
+                -- 기존 봉 업데이트
+                if price > tonumber(c[1]) then redis.call('HSET', KEYS[1], 'high', price) end
+                if price < tonumber(c[2]) then redis.call('HSET', KEYS[1], 'low', price) end
+                redis.call('HSET', KEYS[1], 'close', price)
+                redis.call('HINCRBYFLOAT', KEYS[1], 'vol', vol)
+            end
+            redis.call('EXPIRE', KEYS[1], 10800) -- 3시간 TTL
+            """;
+
     @Override
     public void run(String... args) throws Exception {
         Thread workerThread = new Thread(this::processStream);
         workerThread.setDaemon(true);
         workerThread.start();
-        log.info("[TradeWorker] 정산 프로세스 시작");
+        log.info("[TradeWorker] 정산 프로세스 작동 시작");
     }
 
     @PreDestroy
@@ -59,8 +88,8 @@ public class TradeWorker implements CommandLineRunner {
 
         // Jackson이 OffsetDateTime을 읽을 있도록 JavaTimeModule 등록
         ObjectMapper objectMapper = new ObjectMapper()
-            .registerModule(new JavaTimeModule()) // Java 8 날짜 타입 지원 추가
-            .disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
+                .registerModule(new JavaTimeModule()) // Java 8 날짜 타입 지원 추가
+                .disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
 
         RStream<String, Object> stream = redissonClient.getStream("trade:stream:", new JsonJacksonCodec(objectMapper));
         StreamMessageId lastId = StreamMessageId.ALL; // 처음부터 혹은 최신부터 읽기 설정 가능
@@ -70,17 +99,21 @@ public class TradeWorker implements CommandLineRunner {
                 // 새로운 메시지가 올 때까지 최대 1초 대기
                 // lastId보다 큰 (즉, 나중에 들어온) 데이터를 최대 10개씩 읽기
                 Map<StreamMessageId, Map<String, Object>> messages = stream.read(
-                    StreamReadArgs.greaterThan(lastId).count(10).timeout(Duration.ofSeconds(1)));
+                        StreamReadArgs.greaterThan(lastId).count(10).timeout(Duration.ofSeconds(1)));
 
                 // 데이터가 없으면 건너뛰기
-                if (messages.isEmpty()) continue;
+                if (messages.isEmpty())
+                    continue;
 
                 for (Map.Entry<StreamMessageId, Map<String, Object>> entry : messages.entrySet()) {
+                    StreamMessageId currentId = entry.getKey(); // 현재 처리 중인 메시지의 ID
                     Object data = entry.getValue().get("data");
                     try {
-                        if(data instanceof TransactionRequestDTO) {
+                        // [1] 데이터 처리 로직
+                        if (data instanceof TransactionRequestDTO) {
                             // 1. 체결 정산 처리
-                            TransactionRequestDTO transactionDTO = objectMapper.convertValue(data, TransactionRequestDTO.class);
+                            TransactionRequestDTO transactionDTO = objectMapper.convertValue(data,
+                                    TransactionRequestDTO.class);
                             handleTransaction(transactionDTO);
                         } else if (data instanceof RefundRequestDTO) {
                             // 2. 취소 및 환불 처리
@@ -88,34 +121,194 @@ public class TradeWorker implements CommandLineRunner {
                             handleRefund(refundDTO);
                         }
 
-                        stream.remove(lastId);   // Redis에서 정산 완료한 데이터 제거
-                        lastId = entry.getKey(); // 이후 lastId보다 큰 데이터들을 읽어오기 위해 업데이트
+                        // [2] 처리가 성공하면 즉시 해당 메시지 삭제
+                        stream.remove(currentId);
+
+                        // [3] 다음 읽기 지점을 현재 메시지 이후로 업데이트
+                        lastId = currentId;
+
+                        // stream.remove(lastId); // Redis에서 정산 완료한 데이터 제거
+                        // lastId = entry.getKey(); // 이후 lastId보다 큰 데이터들을 읽어오기 위해 업데이트
                     } catch (Exception e) {
                         log.error("[TradeWorker] 정산 처리 중 오류 발생: ", e);
-                        break;
                     }
                 }
             } catch (Exception e) {
                 log.error("[TradeWorker] 오류 발생: ", e);
                 break;
             }
-
-            try {
-                shutdownLatch.countDown(); // await로 인해 기다리던 래치 풀어주기
-                log.info("[TradeWorker] 워커 스레드가 안전하게 루프를 종료했습니다.");
-            } catch (Exception e) {
-                log.error("[TradeWorker] 종료 정리 중 오류: ", e);
-            }
+        }
+        try {
+            shutdownLatch.countDown(); // await로 인해 기다리던 래치 풀어주기
+            log.info("[TradeWorker] 워커 스레드가 안전하게 루프를 종료했습니다.");
+        } catch (Exception e) {
+            log.error("[TradeWorker] 종료 정리 중 오류: ", e);
         }
     }
 
-    // [체결] DB 프로시저 호출
-    private void handleTransaction(TransactionRequestDTO transactionDTO) {
+    // [체결]
+    private void handleTransaction(TransactionRequestDTO requestDTO) {
+
         try {
-            orderRepository.p_process_transaction_hists(transactionDTO);
-            log.info("[TradeWorker] 체결 정산 완료: TradeID {}", transactionDTO.getTradeId());
+            // 1. [DB] 정산 후 생성된 OUTPUT을 SettlementResultDTO에 담음
+            SettlementResultDTO result = new SettlementResultDTO();
+            orderRepository.p_process_transaction_settlement(requestDTO, result);
+
+            // 2. [DB] DB 기록 용 1분 봉 제작
+            updateRedisCandle(requestDTO);
+
+            // 3. [비동기 기록] 로그 생성 및 버퍼 추가
+            enqueueLogs(requestDTO, result);
+
+            log.info("[TradeWorker] 체결 정산 완료: TradeID {}", requestDTO.getTradeId());
+
         } catch (Exception e) {
-            log.error("[TradeWorker] 체결 정산 실패: TradeID {}, Error: {}", transactionDTO.getTradeId(), e.getMessage());
+
+            log.error("[TradeWorker] 체결 및 정산 실패: TradeID {}", requestDTO.getTradeId(), e);
+
+        }
+    }
+
+    // [DB] 1분 봉 집계 로직
+    private void updateRedisCandle(TransactionRequestDTO trade) {
+
+        // 1분 단위로 버킷팅 (ex: 12:05:33 -> 12:05:00
+        long minute = trade.getCreatedAt().truncatedTo(ChronoUnit.MINUTES).toEpochSecond();
+        String candleKey = "candle:1m:" + trade.getTokenId() + ":" + minute;
+
+        redissonClient.getScript(org.redisson.client.codec.StringCodec.INSTANCE).eval(
+                RScript.Mode.READ_WRITE,
+                luaScript, // 상단에서 작성했던 거
+                RScript.ReturnType.VALUE,
+                List.of(candleKey),
+                trade.getTargetPrice().toPlainString(),
+                trade.getExecutedVolume().toPlainString());
+    }
+
+    // 매 분 5초에 실행
+    // 모으는 건 1분, 저장은 5초 뒤
+    @Scheduled(cron = "5 * * * * *")
+    public void syncCandleToDB() {
+        // 1. 방금 마감된 1분 계산
+        long lastMinute = OffsetDateTime.now().minusMinutes(1).truncatedTo(ChronoUnit.MINUTES).toEpochSecond();
+        String pattern = "candle:1m:*:" + lastMinute;
+
+        try {
+            // 2. 해당 시간내의 모든 토큰 키 찾기
+            Iterable<String> keys = redissonClient.getKeys().getKeysByPattern(pattern);
+
+            // 3. Redisson Batch 기능을 써서 한꺼번에 읽기 준비
+            RBatch batch = redissonClient.createBatch();
+            List<String> keyList = new ArrayList<>();
+
+            for (String key : keys) {
+                keyList.add(key);
+                // "나중에 이 키들 데이터 한꺼번에 읽어올 거야"라고 예약만 함
+                batch.getMap(key, org.redisson.client.codec.StringCodec.INSTANCE).readAllMapAsync();
+            }
+
+            if (keyList.isEmpty()) {
+                return;
+            }
+
+            // 4. 한 번의 네트워크 통신으로 모든 데이터 수집
+            BatchResult<?> result = batch.execute();
+            List<Map<String, String>> allRawData = (List<Map<String, String>>) result.getResponses();
+
+            // 5. 데이터 가공 (String -> BigDecimal & DTO화)
+            List<CandleDTO> candleList = new ArrayList<>();
+            for (int i = 0; i < keyList.size(); i++) {
+
+                Map<String, String> raw = allRawData.get(i);
+                if (raw == null || raw.isEmpty()) continue;
+
+                // 토큰 아이디 추출
+                String[] parts = keyList.get(i).split(":");
+                Long tokenId = Long.valueOf(parts[2]);
+
+                CandleDTO candle = CandleDTO.builder()
+                    .tokenId(tokenId)
+                    .unit(1)
+                    .candleTime(OffsetDateTime.ofInstant(java.time.Instant.ofEpochSecond(lastMinute), ZoneOffset.UTC))
+                    .openingPrice(new BigDecimal(raw.get("open")))
+                    .highPrice(new BigDecimal(raw.get("high")))
+                    .lowPrice(new BigDecimal(raw.get("low")))
+                    .closingPrice(new BigDecimal(raw.get("close")))
+                    .tradeVolume(new BigDecimal(raw.get("vol")))
+                    .build();
+
+                candleList.add(candle);
+            }
+
+            // 5. DB에 한꺼번에 저장
+            if (!candleList.isEmpty()) {
+                orderRepository.insertCandlesBatch(candleList);
+                log.info("[TradeWorker - Sync] {} 시점의 1분 봉 {}건을 DB로 저장 완료", lastMinute, candleList.size());
+            }
+
+        } catch (Exception e) {
+            log.error("[TradeWorker - Sync] 1분 봉 DB 동기화 중 오류 발생: ", e);
+        }
+    }
+
+    // [DB] 체결 내역 생성
+    // TransactionRequestDTO 누가 누구랑 얼마에 체결됐는가?
+    // SettlementResultDTO 정산 후 잔액이 얼마가 되었는가?
+    private void enqueueLogs(TransactionRequestDTO t, SettlementResultDTO r) {
+        BigDecimal execAmount = t.getTargetPrice().multiply(t.getExecutedVolume());
+
+        // 매수자 로그 (CASH OUT, TOKEN IN)
+        tradeBuffer.add(buildLog(t.getTxId1(), t.getTradeId(), t.getBuyOrderId(),
+                t.getBuyWalletId(), "CASH", "OUT",
+                execAmount, r.getBuyCashAfter(), r.getBuyRemToken(),
+                r.getBuyRemCash(), BigDecimal.ZERO, t.getCreatedAt()));
+
+        tradeBuffer.add(buildLog(t.getTxId2(), t.getTradeId(), t.getBuyOrderId(),
+                t.getBuyWalletId(), "TOKEN", "IN",
+                t.getExecutedVolume(), r.getBuyTokenAfter(), r.getBuyRemToken(),
+                r.getBuyRemCash(), t.getFeeRate().multiply(t.getExecutedVolume()), t.getCreatedAt()));
+
+        // 매도자 로그 (CASH IN, TOKEN OUT)
+        tradeBuffer.add(buildLog(t.getTxId3(), t.getTradeId(), t.getSellOrderId(),
+                t.getSellWalletId(), "CASH", "IN",
+                execAmount, r.getSellCashAfter(), r.getSellRemToken(),
+                r.getSellRemCash(),t.getFeeRate().multiply(execAmount), t.getCreatedAt()));
+
+        tradeBuffer.add(buildLog(t.getTxId4(), t.getTradeId(), t.getSellOrderId(),
+                t.getSellWalletId(), "TOKEN", "OUT", t.getExecutedVolume(),
+                r.getSellTokenAfter(), r.getSellRemToken(), r.getSellRemCash(),
+                BigDecimal.ZERO, t.getCreatedAt()));
+    }
+
+    // 체결 내역 생성을 위한 builder
+    private TransactionHistDTO buildLog(Long txId, Long tradeId, Long orderId, Long walletId, String asset,
+            String dir, BigDecimal amt, BigDecimal bal, BigDecimal remVol, BigDecimal remPrice, BigDecimal fee,
+            OffsetDateTime time) {
+        return TransactionHistDTO.builder()
+                .transactionId(txId).tradeId(tradeId).orderId(orderId).walletId(walletId)
+                .transactionType("TRADE").assetType(asset).direction(dir).amount(amt)
+                .balanceAfter(bal).remainingVolume(remVol).remainingPrice(remPrice)
+                .fee(fee)
+                .hashValue(txId + "_" + tradeId)
+                .createdAt(time).build();
+    }
+
+    // [DB] 1초마다 혹은 버퍼가 차면 DB에 한 번에 저장
+    @Scheduled(fixedDelay = 1000)
+    public void periodFlush() {
+
+        if (tradeBuffer.isEmpty()) {
+            return;
+        }
+
+        List<TransactionHistDTO> tradeToSave = new ArrayList<>();
+        while (!tradeBuffer.isEmpty() && tradeToSave.size() < 1000) {
+            tradeToSave.add(tradeBuffer.poll());
+        }
+
+        if (!tradeToSave.isEmpty()) {
+            orderRepository.bulkInsertTradeHistory(tradeToSave);
+            log.info("[DB] {}건의 체결 내역 저장 완료", tradeToSave.size());
         }
     }
 

--- a/src/main/java/com/kanghwang/khholdings/domain/order/bot/TradingSimulationBot.java
+++ b/src/main/java/com/kanghwang/khholdings/domain/order/bot/TradingSimulationBot.java
@@ -31,7 +31,7 @@ public class TradingSimulationBot {
 
 	// 0.3초마다 주문
 	@Async
-	@Scheduled(fixedDelay = 10)
+	@Scheduled(fixedDelay = 300)
 	public void runSimulation() {
 		if (!isRunning) {
 			return;
@@ -50,7 +50,7 @@ public class TradingSimulationBot {
 			orderService.placeOrder(randomOrder);
 
 		} catch (Exception e) {
-			log.error(">>>> [BOT] 주문 처리 중 오류: {}", e.getMessage());
+			log.error(">>>> [BOT] 주문 처리 중 오류: ", e);
 		}
 	}
 

--- a/src/main/java/com/kanghwang/khholdings/domain/order/dto/CandleDTO.java
+++ b/src/main/java/com/kanghwang/khholdings/domain/order/dto/CandleDTO.java
@@ -1,0 +1,24 @@
+package com.kanghwang.khholdings.domain.order.dto;
+
+import lombok.*;
+
+import java.math.BigDecimal;
+import java.time.OffsetDateTime;
+
+
+@Getter
+@Setter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class CandleDTO {
+    private Long tokenId;               // 토큰 고유 번호
+    private Integer unit;               // unit (1분봉이면 1)
+    private OffsetDateTime candleTime;  // 캔들 기준 시간
+
+    private BigDecimal openingPrice;    // 시가
+    private BigDecimal highPrice;       // 고가
+    private BigDecimal lowPrice;        // 저가
+    private BigDecimal closingPrice;    // 종가
+    private BigDecimal tradeVolume;     // 거래량
+}

--- a/src/main/java/com/kanghwang/khholdings/domain/order/dto/SettlementResultDTO.java
+++ b/src/main/java/com/kanghwang/khholdings/domain/order/dto/SettlementResultDTO.java
@@ -1,0 +1,19 @@
+package com.kanghwang.khholdings.domain.order.dto;
+
+import lombok.Getter;
+import lombok.Setter;
+
+import java.math.BigDecimal;
+
+@Getter
+@Setter
+public class SettlementResultDTO {
+    private BigDecimal buyCashAfter;        // 매수자 체결 후 현금 잔액
+    private BigDecimal buyTokenAfter;       // 매수자 체결 후 토큰 잔액
+    private BigDecimal sellCashAfter;       // 매도자 체결 후 현금 잔액
+    private BigDecimal sellTokenAfter;      // 매도자 체결 후 토큰 잔액
+    private BigDecimal buyRemCash;          // 매수 주문 잔량 (현금)
+    private BigDecimal buyRemToken;         // 매수 주문 잔량 (토큰)
+    private BigDecimal sellRemCash;         // 매도 주문 잔량 (현금)
+    private BigDecimal sellRemToken;        // 매도 주문 잔량 (토큰)
+}

--- a/src/main/java/com/kanghwang/khholdings/domain/order/dto/TransactionHisttDTO.java
+++ b/src/main/java/com/kanghwang/khholdings/domain/order/dto/TransactionHisttDTO.java
@@ -1,0 +1,31 @@
+package com.kanghwang.khholdings.domain.order.dto;
+
+import com.kanghwang.khholdings.domain.order.type.OrderSide;
+import lombok.*;
+
+import java.io.Serializable;
+import java.math.BigDecimal;
+import java.time.OffsetDateTime;
+
+@Getter
+@Setter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class TransactionHisttDTO {
+
+	private Long transactionId; 			// p_tx_id
+	private Long tradeId;
+	private Long orderId;
+	private Long walletId;
+	private String transactionType; 		// 'TRADE'
+	private String assetType; 				// 'CASH', 'TOKEN'
+	private String direction; 				// 'IN', 'OUT'
+	private BigDecimal amount; 				// 체결 금액 또는 수량
+	private BigDecimal balanceAfter;
+	private BigDecimal remainingVolume;
+	private BigDecimal remainingPrice;
+	private BigDecimal fee;
+	private String hashValue;
+	private OffsetDateTime createdAt;
+}

--- a/src/main/java/com/kanghwang/khholdings/domain/order/dto/TransactionRequestDTO.java
+++ b/src/main/java/com/kanghwang/khholdings/domain/order/dto/TransactionRequestDTO.java
@@ -33,4 +33,7 @@ public class TransactionRequestDTO implements Serializable {
 	private BigDecimal feeRate;
 	private OffsetDateTime createdAt; 		// 체결 시각
 	private OrderSide takerSide;       		// 체결을 유발한 쪽 (=나, BUY or SELL)
+	private Long tokenId;      				// 어떤 종목인지 식별
+	private Long buyWalletId;  				// 매수자 지갑 (체결 목록 저장 dto에 전달 위함)
+	private Long sellWalletId; 				// 매도자 지갑 (체결 목록 저장 dto에 전달 위함)
 }

--- a/src/main/java/com/kanghwang/khholdings/domain/order/service/OrderRedisService.java
+++ b/src/main/java/com/kanghwang/khholdings/domain/order/service/OrderRedisService.java
@@ -38,6 +38,7 @@ public class OrderRedisService {
 		.registerModule(new JavaTimeModule()) // Java 8 날짜 타입 지원 추가
 		.disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
 
+	private final SnowflakeIdGenerator snowflakeIdGenerator;
 	private final RedissonClient redissonClient;
 	private static final BigDecimal F_RATE = new BigDecimal("0.0006"); // 수수료 관리
 
@@ -85,8 +86,15 @@ public class OrderRedisService {
 			// 매수인 경우, 내림차순 정렬을 위해 가격을 음수로 변환
 			score = score.negate();
 		}
-		myOrderBook.add(score.doubleValue(), myOrderId); // 해당 토큰 호가창에 내 주문 등록
+
+		if (myOrderDTO.getOrderType() == OrderType.LIMIT) {
+			// 처음부터 지정가만 호가창에 들어가도록
+			myOrderBook.add(score.doubleValue(), myOrderId); // 해당 토큰 호가창에 내 주문 등록
+		}
+
 		infoMap.put(myOrderId, myOrderDTO); // 해당 토큰 주문 상세에 내 주문 등록
+
+
 
 		// 지정가 주문 정보를 실시간으로 전파 -> MarketWorker가 받아서 웹소켓으로 전송
 		// if (myOrderDTO.getOrderType() == OrderType.LIMIT) {
@@ -180,17 +188,20 @@ public class OrderRedisService {
 			
 			BigDecimal executedAmount = targetPrice.multiply(executedVolume); // 총 체결 = 상대방 단가(가장 유리) * 체결할 수량
 
-			Long tradeId = SnowflakeIdGenerator.nextId(); // 체결 번호 (매수-매도 체결에 대해 동일한 번호 부여)
-			Long txId1 = SnowflakeIdGenerator.nextId();   // 거래 내역 번호 - 매수자 현금 지출
-			Long txId2 = SnowflakeIdGenerator.nextId();   // 거래 내역 번호 - 매수자 토큰 유입
-			Long txId3 = SnowflakeIdGenerator.nextId();   // 거래 내역 번호 - 매도자 현금 유입
-			Long txId4 = SnowflakeIdGenerator.nextId();   // 거래 내역 번호 - 매도자 토큰 지출
+			Long tradeId = snowflakeIdGenerator.nextId(); // 체결 번호 (매수-매도 체결에 대해 동일한 번호 부여)
+			Long txId1 = snowflakeIdGenerator.nextId();   // 거래 내역 번호 - 매수자 현금 지출
+			Long txId2 = snowflakeIdGenerator.nextId();   // 거래 내역 번호 - 매수자 토큰 유입
+			Long txId3 = snowflakeIdGenerator.nextId();   // 거래 내역 번호 - 매도자 현금 유입
+			Long txId4 = snowflakeIdGenerator.nextId();   // 거래 내역 번호 - 매도자 토큰 지출
 
+			long tokenId = myOrderDTO.getTokenId();
+			long buyWalletId = (myOrderDTO.getOrderSide() == OrderSide.BUY) ? myOrderDTO.getWalletId() : targetOrderDTO.getWalletId();
+			long sellWalletId = (myOrderDTO.getOrderSide() == OrderSide.SELL) ? myOrderDTO.getWalletId() : targetOrderDTO.getWalletId();
 			long buyOrderId = (myOrderDTO.getOrderSide() == OrderSide.BUY) ? myOrderId : targetOrderId;
 			long sellOrderId = (myOrderDTO.getOrderSide() == OrderSide.SELL) ? myOrderId : targetOrderId;
 
 			TransactionRequestDTO transactionDTO = new TransactionRequestDTO(txId1, txId2, txId3, txId4, tradeId, buyOrderId, sellOrderId, targetPrice, executedVolume, F_RATE,
-				OffsetDateTime.now(), mySide);
+				OffsetDateTime.now(), mySide, tokenId, buyWalletId, sellWalletId);
 
 			// 체결이 발생할 때마다 Redis에 데이터 전달
 			// -> DB 저장 / 웹소켓 실시간 전송
@@ -280,7 +291,7 @@ public class OrderRedisService {
 					&& myOrderDTO.getOrderSide() == OrderSide.BUY
 					&& myOrderDTO.getRemainingCash().compareTo(BigDecimal.ZERO) > 0) {
 				// 비동기 정산 및 이력 저장용 Stream에 저장 후 DB 프로시저 호출
-				RefundRequestDTO refundRequestDTO = new RefundRequestDTO(SnowflakeIdGenerator.nextId(), myOrderDTO.getOrderId(), myOrderDTO.getRemainingCash(), BigDecimal.ZERO);
+				RefundRequestDTO refundRequestDTO = new RefundRequestDTO(snowflakeIdGenerator.nextId(), myOrderDTO.getOrderId(), myOrderDTO.getRemainingCash(), BigDecimal.ZERO);
 				redissonClient.getStream("trade:stream:", new JsonJacksonCodec(objectMapper))
 					.add(StreamAddArgs.entry("data", refundRequestDTO));
 				log.info("지정가 매수 차액 환불: 주문ID {}, 환불금액 {}", myOrderDTO.getOrderId(), myOrderDTO.getRemainingCash());
@@ -292,7 +303,7 @@ public class OrderRedisService {
 			if (myOrderDTO.getOrderType() == OrderType.MARKET) {
 				// 1) 시장가 주문은 미체결 수량 즉시 환불
 				// 비동기 정산 및 이력 저장용 Stream에 저장 후 DB 프로시저 호출
-				RefundRequestDTO refundRequestDTO = new RefundRequestDTO(SnowflakeIdGenerator.nextId(), myOrderDTO.getOrderId(), myOrderDTO.getRemainingCash(), myOrderDTO.getRemainingToken());
+				RefundRequestDTO refundRequestDTO = new RefundRequestDTO(snowflakeIdGenerator.nextId(), myOrderDTO.getOrderId(), myOrderDTO.getRemainingCash(), myOrderDTO.getRemainingToken());
 				redissonClient.getStream("trade:stream:", new JsonJacksonCodec(objectMapper))
 					.add(StreamAddArgs.entry("data", refundRequestDTO));
 				log.info("시장가 주문 매칭 종료로 잔량 환불: OrderId {}", myOrderDTO.getOrderId());
@@ -337,7 +348,7 @@ public class OrderRedisService {
 			removeOrder(orderInfo.getTokenId(), orderInfo.getOrderSide(), orderId);
 
 			// 3. 비동기 정산 및 이력 저장용 Stream에 저장 후 DB 프로시저 호출
-			RefundRequestDTO refundRequestDTO = new RefundRequestDTO(SnowflakeIdGenerator.nextId(), orderId, orderInfo.getRemainingCash(), orderInfo.getRemainingToken());
+			RefundRequestDTO refundRequestDTO = new RefundRequestDTO(snowflakeIdGenerator.nextId(), orderId, orderInfo.getRemainingCash(), orderInfo.getRemainingToken());
 			redissonClient.getStream("trade:stream:", new JsonJacksonCodec(objectMapper))
 				.add(StreamAddArgs.entry("data", refundRequestDTO));
 

--- a/src/main/java/com/kanghwang/khholdings/domain/project/ProjectService.java
+++ b/src/main/java/com/kanghwang/khholdings/domain/project/ProjectService.java
@@ -26,13 +26,14 @@ public class ProjectService {
 
 	private final ProjectRepository projectRepository;
 	private final MarketRepository marketRepository;
+	private final SnowflakeIdGenerator snowflakeIdGenerator;
 
 	// 청약 신청
 	@Transactional
 	public Long applySubscription(Long tokenId, Long subscriptionId, Long walletId, BigDecimal amount) {
 
 		// 1. Snowflake ID 생성
-		Long transactionId = SnowflakeIdGenerator.nextId();
+		Long transactionId = snowflakeIdGenerator.nextId();
 
 		// 2. 해시값 생성
 		String hashValue = DigestUtils.sha256Hex(transactionId.toString() + walletId.toString());
@@ -53,7 +54,7 @@ public class ProjectService {
 	public boolean cancelSubscription(Long transactionId) {
 
 		// 1. Snowflake ID 생성
-		Long newTransactionId = SnowflakeIdGenerator.nextId();
+		Long newTransactionId = snowflakeIdGenerator.nextId();
 
 		// 2. 해시값 생성
 		String hashValue = DigestUtils.sha256Hex(transactionId.toString());
@@ -75,8 +76,8 @@ public class ProjectService {
 		for (SubscriptionRequestDTO subRequestDTO : subRequestList) {
 
 			// 1. Snowflake ID 생성
-			Long passTxId = SnowflakeIdGenerator.nextId();
-			Long failTxId = SnowflakeIdGenerator.nextId();
+			Long passTxId = snowflakeIdGenerator.nextId();
+			Long failTxId = snowflakeIdGenerator.nextId();
 
 			// 2. 해시값 생성
 			String passHashValue = DigestUtils.sha256Hex(passTxId.toString());
@@ -136,7 +137,7 @@ public class ProjectService {
 
 		for (DividendRequestDTO dividendRequestDTO : divRequestList) {
 
-			Long transactionId = SnowflakeIdGenerator.nextId();
+			Long transactionId = snowflakeIdGenerator.nextId();
 			String hashValue = DigestUtils.sha256Hex(transactionId.toString());
 
 			DividendDTO dividendDTO = DividendDTO.builder()
@@ -200,8 +201,8 @@ public class ProjectService {
 			BigDecimal amount = holder.getTotalBalance();          // 토큰 보유 수량
 			BigDecimal cashAmount = amount.multiply(currentPrice); // 시세를 기준으로 환전
 
-			Long txId1 = SnowflakeIdGenerator.nextId();
-			Long txId2 = SnowflakeIdGenerator.nextId();
+			Long txId1 = snowflakeIdGenerator.nextId();
+			Long txId2 = snowflakeIdGenerator.nextId();
 
 			BurnDTO burnDTO = BurnDTO.builder()
 				.txId1(txId1)

--- a/src/main/java/com/kanghwang/khholdings/global/util/SnowflakeIdGenerator.java
+++ b/src/main/java/com/kanghwang/khholdings/global/util/SnowflakeIdGenerator.java
@@ -6,22 +6,22 @@ import org.springframework.stereotype.Component;
 public class SnowflakeIdGenerator {
 
     // 1. 기준 시간 (바꾸지 마세요. 유지해야 과거 ID와 정렬이 맞습니다)
-    private static final long epoch = 1767193200000L; // 2026-01-01
+    private final long epoch = 1767193200000L; // 2026-01-01
 
     // 2. 비트 할당 (표준 규격)
-    private static final long sequenceBits = 12L;   // 1ms당 4096개 생성 가능
-    private static final long workerIdBits = 5L;     // 서버 식별 (서버 1대라도 자리 비워둠)
+    private final long sequenceBits = 12L;   // 1ms당 4096개 생성 가능
+    private final long workerIdBits = 5L;     // 서버 식별 (서버 1대라도 자리 비워둠)
 
     // 3. 밀기 연산 (이 숫자들이 시간 데이터를 결정합니다)
-    private static final long workerIdShift = sequenceBits; // 12칸
-    private static final long timestampLeftShift = sequenceBits + workerIdBits; // 17칸
-    private static final long sequenceMask = -1L ^ (-1L << sequenceBits); // 4095
+    private final long workerIdShift = sequenceBits; // 12칸
+    private final long timestampLeftShift = sequenceBits + workerIdBits; // 17칸
+    private final long sequenceMask = -1L ^ (-1L << sequenceBits); // 4095
 
-    private static long lastTimestamp = -1L;
-    private static long sequence = 0L;
-    private static final long workerId = 0L; // 현재 서버 1대이므로 0 고정
+    private long lastTimestamp = -1L;
+    private long sequence = 0L;
+    private final long workerId = 0L; // 현재 서버 1대이므로 0 고정
 
-    public static synchronized long nextId() {
+    public synchronized long nextId() {
         long timestamp = timeGen();
 
         if (timestamp < lastTimestamp) {
@@ -49,7 +49,7 @@ public class SnowflakeIdGenerator {
             sequence;
     }
 
-    protected static Long tilNextMillis(Long lastTimestamp) {
+    protected Long tilNextMillis(Long lastTimestamp) {
         Long timestamp = timeGen();
         while (timestamp <= lastTimestamp) {
             timestamp = timeGen();
@@ -57,7 +57,7 @@ public class SnowflakeIdGenerator {
         return timestamp;
     }
 
-    protected static Long timeGen() {
+    protected Long timeGen() {
         return System.currentTimeMillis();
     }
 }

--- a/src/main/resources/mapper/MyMapper.xml
+++ b/src/main/resources/mapper/MyMapper.xml
@@ -11,8 +11,8 @@
                 token_id,
                 closing_price
             FROM token_quotes
-            WHERE unit = '1m'::quote_unit_enum
-            ORDER BY token_id, created_at DESC
+            WHERE unit = 1
+            ORDER BY token_id, candle_time DESC
         ),
         wallet_stats AS (
             SELECT
@@ -49,8 +49,8 @@
             token_id,
             closing_price
         FROM token_quotes
-        WHERE unit = '1m'::quote_unit_enum
-        ORDER BY token_id, created_at DESC
+        WHERE unit = 1
+        ORDER BY token_id, candle_time DESC
             )
         SELECT
             t.token_name           AS tokenName,

--- a/src/main/resources/mapper/OrderMapper.xml
+++ b/src/main/resources/mapper/OrderMapper.xml
@@ -3,6 +3,7 @@
 
 <mapper namespace="com.kanghwang.khholdings.domain.order.OrderRepository">
 
+    <!-- 특정 토큰 보유 수량 조회 -->
     <select id="selectHoldingTokenBalance" parameterType="Long" resultType="bigdecimal">
         SELECT
             COALESCE(token_balance, 0)
@@ -14,6 +15,7 @@
             wallet_id = #{walletId}
     </select>
 
+    <!-- 사용 가능한 잔액 조회 -->
     <select id="selectAvailableBalance" parameterType="Long" resultType="bigdecimal">
         SELECT
             (cash_balance - frozen_amount)
@@ -23,6 +25,7 @@
             wallet_id  = #{walletId}
     </select>
 
+    <!-- 주문 프로시저 -->
     <update id="callPlaceOrderProcedure" parameterType="OrderRequestDTO" statementType="CALLABLE">
         CALL p_create_order(
             #{orderId},
@@ -36,22 +39,28 @@
         )
     </update>
 
-    <update id="p_process_transaction_hists" parameterType="TransactionRequestDTO" statementType="CALLABLE">
-        CALL p_process_transaction_hists(
-            #{txId1},
-            #{txId2},
-            #{txId3},
-            #{txId4},
-            #{tradeId},
-            #{buyOrderId},
-            #{sellOrderId},
-            #{targetPrice},
-            #{executedVolume},
-            #{feeRate},
-            #{createdAt}
+    <!-- 정산 전용 프로시저 호출 (OUT 파라미터 매핑) -->
+    <update id="p_process_transaction_settlement" statementType="CALLABLE">
+        CALL p_process_transaction_settlement(
+            #{trade.tradeId},
+            #{trade.buyOrderId},
+            #{trade.sellOrderId},
+            #{trade.targetPrice},
+            #{trade.executedVolume},
+            #{result.buyCashAfter, mode=OUT, jdbcType=NUMERIC},
+            #{result.buyTokenAfter, mode=OUT, jdbcType=NUMERIC},
+            #{result.sellCashAfter, mode=OUT, jdbcType=NUMERIC},
+            #{result.sellTokenAfter, mode=OUT, jdbcType=NUMERIC},
+            #{result.buyRemCash, mode=OUT, jdbcType=NUMERIC},
+            #{result.buyRemToken, mode=OUT, jdbcType=NUMERIC},
+            #{result.sellRemCash, mode=OUT, jdbcType=NUMERIC},
+            #{result.sellRemToken, mode=OUT, jdbcType=NUMERIC},
+            #{trade.feeRate, jdbcType=NUMERIC},
+            #{trade.createdAt, jdbcType=TIMESTAMP}
         )
     </update>
 
+    <!-- 환불 프로시저 -->
     <update id="p_cancel_order_and_refund" parameterType="RefundRequestDTO" statementType="CALLABLE">
         CALL p_cancel_order_and_refund(
             #{txId},
@@ -60,4 +69,47 @@
             #{remainingToken}
         )
     </update>
+
+    <!-- 체결 내역 벌크 인서트 -->
+    <insert id="bulkInsertTradeHistory">
+        INSERT INTO kh_holdings.transaction_hists (
+        transaction_id, trade_id, order_id, wallet_id,
+        transaction_type, asset_type, direction, amount,
+        balance_after, remaining_volume, remaining_price, fee,
+        hash_value, created_at
+        ) VALUES
+        <foreach collection="list" item="h" separator=",">
+            (
+            #{h.transactionId}, #{h.tradeId}, #{h.orderId}, #{h.walletId},
+            #{h.transactionType}::kh_holdings.transaction_type_enum,
+            #{h.assetType}::kh_holdings.asset_type_enum,
+            #{h.direction}::kh_holdings.direction_enum,
+            #{h.amount}, #{h.balanceAfter}, #{h.remainingVolume},
+            #{h.remainingPrice}, #{h.fee}, #{h.hashValue}, #{h.createdAt}
+            )
+        </foreach>
+    </insert>
+
+    <!-- 1분 봉 데이터 벌크 인서트 -->
+    <insert id="insertCandlesBatch">
+        INSERT INTO token_quotes (
+            token_id, candle_time, opening_price,
+            high_price, low_price, closing_price,
+            trade_volume, unit
+        ) VALUES
+        <foreach collection="list" item="c" separator=",">
+            (
+            #{c.tokenId}, #{c.candleTime},
+            #{c.openingPrice}::numeric, #{c.highPrice}::numeric,
+            #{c.lowPrice}::numeric, #{c.closingPrice}::numeric,
+            #{c.tradeVolume}::numeric, 1
+            )
+        </foreach>
+        ON CONFLICT (token_id, candle_time)
+        DO UPDATE SET
+            high_price = EXCLUDED.high_price,
+            low_price = EXCLUDED.low_price,
+            closing_price = EXCLUDED.closing_price,
+            trade_volume = EXCLUDED.trade_volume
+    </insert>
 </mapper>


### PR DESCRIPTION
## 📌 작업 내용 요약 (Summary)
- 정산 전용 프로시저 도입: 기존의 p_process_transaction_hists를 정산 전용(p_process_transaction_settlement)으로 분리
- 지갑 잔액과 주문 상태만 프로시저에서 즉시 처리하여 DB 부하를 최소화하고 데이터 원자성을 확보함.
- Lua Script 기반 집계: Redis 내부에서 Lua 스크립트를 통해 체결 즉시 실시간(Real-time) 캔들을 생성함.
- RBatch 기반 동기화: TradeWorker가 매 분 5초마다 RBatch를 사용해 Redis의 완성된 봉 데이터를 DB(token_quotes)로 대량 동기화(Bulk Insert).
- 캔들 정보 웹소켓 연동

## 📝 변경 사항 (Key Changes)
- [ ] 
- [ ] 

## 📸 스크린샷 (Screenshots / Demos)
| Feature | Screenshot |
| :--- | :--- |
| 기능명 | 사진첨부 |

## 🔗 연관된 이슈 (Related Issues)
- Close #56 
- Close #57 

## 🧐 주요 리뷰 포인트 (Review Point)
- 

## ✅ 최종 PR전 체크 리스트 (Checklist)
- [ ] 코딩 컨벤션(Checkstyle)을 준수하였는가?
- [ ] 불필요한 주석이나 시스템 로그(console.log, print)를 제거하였는가?
- [ ] 변경 사항에 대한 테스트를 완료하였는가?
- [ ] 관련 문서를 업데이트하였는가?
