### PR TITLE
[FIX] 웹소켓 호가창 중복 전송 해결

### DIFF
--- a/src/main/java/com/kanghwang/khholdings/domain/order/OrderController.java
+++ b/src/main/java/com/kanghwang/khholdings/domain/order/OrderController.java
@@ -13,6 +13,7 @@ import org.springframework.web.bind.annotation.RestController;
 
 import com.kanghwang.khholdings.domain.order.dto.OrderRequestDTO;
 import com.kanghwang.khholdings.domain.order.service.OrderService;
+import com.kanghwang.khholdings.global.dto.ApiResponse;
 
 @RestController
 @RequestMapping("/api/order")
@@ -23,14 +24,22 @@ public class OrderController {
 
 	// 해당 토큰 보유 수량 조회
 	@GetMapping("/balance/{walletId}/{tokenId}")
-	public BigDecimal selectHoldingTokenBalance(@PathVariable Long walletId, @PathVariable Long tokenId) {
-		return orderService.selectHoldingTokenBalance(walletId, tokenId);
+	public ResponseEntity<ApiResponse<BigDecimal>> selectHoldingTokenBalance(@PathVariable Long walletId, @PathVariable Long tokenId) {
+		BigDecimal tokenBalance = orderService.selectHoldingTokenBalance(walletId, tokenId);
+		if (tokenBalance == null) {
+			return ResponseEntity.badRequest().body(ApiResponse.error("토큰 보유 수량 조회에 실패했습니다."));
+		}
+		return ResponseEntity.ok(ApiResponse.success("보유 토큰 조회에 성공했습니다.", tokenBalance));
 	}
 
 	// 주문 가능 금액 조회
 	@GetMapping("/balance/{walletId}")
-	public BigDecimal selectAvailableBalance(@PathVariable Long walletId) {
-		return orderService.selectAvailableBalance(walletId);
+	public ResponseEntity<ApiResponse<BigDecimal>> selectAvailableBalance(@PathVariable Long walletId) {
+		BigDecimal cashBalance = orderService.selectAvailableBalance(walletId);
+		if (cashBalance == null) {
+			return ResponseEntity.badRequest().body(ApiResponse.error("주문 가능 금액 조회에 실패했습니다."));
+		}
+		return ResponseEntity.ok(ApiResponse.success("주문 가능 금액 조회에 성공했습니다.", cashBalance));
 	}
 
 	// 매수/매도 주문

--- a/src/main/java/com/kanghwang/khholdings/domain/order/service/OrderRedisService.java
+++ b/src/main/java/com/kanghwang/khholdings/domain/order/service/OrderRedisService.java
@@ -25,6 +25,7 @@ import com.kanghwang.khholdings.global.util.SnowflakeIdGenerator;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
+
 @Slf4j
 @Service
 @RequiredArgsConstructor
@@ -80,15 +81,15 @@ public class OrderRedisService {
 				// 매수인 경우, 내림차순 정렬을 위해 가격을 음수로 변환
 				score = score.negate();
 			}
-			myOrderBook.add(score.doubleValue(), myOrderId); // 해당 토큰 호가창에 내 주문 등록
+
+			// 매칭 엔진 내 호가창 (-> 체결이 이루어짐)
+			myOrderBook.add(score.doubleValue(), myOrderId);
+
+			// 웹소켓 호가창 (-> 토큰 거래소에 호가를 띄워줌)
+			updateAggrOrderBook(myOrderDTO.getTokenId(), mySide, myOrderDTO.getOrderPrice(), myOrderDTO.getOrderVolume());
 		}
 
 		infoMap.put(myOrderId, myOrderDTO); // 해당 토큰 주문 상세에 내 주문 등록
-
-		// 웹소켓 호가창 등록 -> MarketWorker가 실시간으로 받아서 브라우저에 전송
-		if (myOrderDTO.getOrderType() == OrderType.LIMIT) {
-			updateAggrOrderBook(myOrderDTO.getTokenId(), mySide, myOrderDTO.getOrderPrice(), myOrderDTO.getOrderVolume());
-		}
 
 		while (true) {
 
@@ -123,8 +124,8 @@ public class OrderRedisService {
 
 			// 상대방이 매수인 경우, 가격을 양수로 변환 (<-Sorted Set을 내림차순 정렬하기 위해 음수로 변환해서 넣음)
 			BigDecimal targetPrice = (counterSide == OrderSide.BUY)
-					? targetScore.negate()
-					: targetScore;
+				? targetScore.negate()
+				: targetScore;
 
 
 			// [Step 2] 지정가 주문(me)인 경우, 가격 조건 확인 (내 가격 vs 상대방 가격)
@@ -224,7 +225,7 @@ public class OrderRedisService {
 			// (3) 현재가 갱신 (예: "ticker:last_price:{tokenId}")
 			// Redis에 해당 토큰의 마지막 체결가를 저장
 			redissonClient.getBucket(redisKeyManager.getPrefix() + "ticker:last_price:" + myOrderDTO.getTokenId())
-					.set(targetPrice);
+				.set(targetPrice);
 
 			log.info("체결: Price {}, Volume {}, Amount {}", targetPrice.toPlainString(), executedVolume.toPlainString(), executedAmount.toPlainString());
 			log.info("Worker에게 나머지 작업 전달: TradeID {}", tradeId);
@@ -232,7 +233,7 @@ public class OrderRedisService {
 			// [Step 4] 자산 정산 (미체결 수량 및 금액 갱신)
 			// 1) 나
 			if (myOrderDTO.getOrderSide() == OrderSide.SELL
-					|| (myOrderDTO.getOrderSide() == OrderSide.BUY && myOrderDTO.getOrderType() == OrderType.LIMIT)) {
+				|| (myOrderDTO.getOrderSide() == OrderSide.BUY && myOrderDTO.getOrderType() == OrderType.LIMIT)) {
 				myOrderDTO.setRemainingToken(myOrderDTO.getRemainingToken().subtract(executedVolume));
 			}
 			if (myOrderDTO.getOrderSide() == OrderSide.BUY) {
@@ -240,7 +241,7 @@ public class OrderRedisService {
 			}
 			// 2) 상대방
 			if (targetOrderDTO.getOrderSide() == OrderSide.SELL
-					|| (targetOrderDTO.getOrderSide() == OrderSide.BUY && targetOrderDTO.getOrderType() == OrderType.LIMIT)) {
+				|| (targetOrderDTO.getOrderSide() == OrderSide.BUY && targetOrderDTO.getOrderType() == OrderType.LIMIT)) {
 				targetOrderDTO.setRemainingToken(targetOrderDTO.getRemainingToken().subtract(executedVolume));
 			}
 			if (targetOrderDTO.getOrderSide() == OrderSide.BUY) {
@@ -249,6 +250,9 @@ public class OrderRedisService {
 
 			// [Step 5] 호가창 업데이트
 			// 1) 나
+			if (myOrderDTO.getOrderType() == OrderType.LIMIT) {
+				updateAggrOrderBook(myOrderDTO.getTokenId(), mySide, myOrderDTO.getOrderPrice(), executedVolume.negate());
+			}
 			infoMap.put(myOrderId, myOrderDTO);
 
 			// 2) 상대방
@@ -286,16 +290,10 @@ public class OrderRedisService {
 		// 	removeOrder(myOrderDTO.getTokenId(), mySide, myOrderDTO.getOrderId());
 		// }
 
-		// 웹소켓 호가창 업데이트 또는 삭제 -> MarketWorker가 실시간으로 받아서 브라우저에 전송
-		BigDecimal executedVolume = myOrderDTO.getOrderVolume().subtract(myOrderDTO.getRemainingToken());
-		if (myOrderDTO.getOrderType() == OrderType.LIMIT) {
-			updateAggrOrderBook(myOrderDTO.getTokenId(), mySide, myOrderDTO.getOrderPrice(), executedVolume.negate());
-		}
-
 		if (isCompleted) {
 			// 지정가 매수인데 주문 요청 금액보다 싸게 사서 돈이 남은 경우 추가 환불
 			if (myOrderDTO.getOrderType() == OrderType.LIMIT && myOrderDTO.getOrderSide() == OrderSide.BUY
-					&& myOrderDTO.getRemainingCash().compareTo(BigDecimal.ZERO) > 0) {
+				&& myOrderDTO.getRemainingCash().compareTo(BigDecimal.ZERO) > 0) {
 				// 비동기 정산 및 이력 저장용 Stream에 저장 후 DB 프로시저 호출
 				RefundRequestDTO refundRequestDTO = new RefundRequestDTO(snowflakeIdGenerator.nextId(), myOrderDTO.getOrderId(), myOrderDTO.getRemainingCash(), BigDecimal.ZERO);
 				redissonClient.getStream(redisKeyManager.getPrefix() + "trade:stream:")


### PR DESCRIPTION
## 📌 작업 내용 요약 (Summary)
- 웹소켓 호가창 중복 전송 해결
- 주문 가능 금액, 보유 토큰 수량 조회 API 응답 형태 수정

## 📝 변경 사항 (Key Changes)
- [ ] OrderRedisService에서 updateAggrOrderBook()을 finalizeOrderProcess() 내에서가 아닌 매칭 루프 내에서 체결될 때마다 호출
- [ ] OrderController

## 📸 스크린샷 (Screenshots / Demos)
| Feature | Screenshot |
| :--- | :--- |
| 기능명 | 사진첨부 |

## 🔗 연관된 이슈 (Related Issues)
- Close #

## 🧐 주요 리뷰 포인트 (Review Point)
- 

## ✅ 최종 PR전 체크 리스트 (Checklist)
- [ ] 코딩 컨벤션(Checkstyle)을 준수하였는가?
- [ ] 불필요한 주석이나 시스템 로그(console.log, print)를 제거하였는가?
- [ ] 변경 사항에 대한 테스트를 완료하였는가?
- [ ] 관련 문서를 업데이트하였는가?
