### PR TITLE
[FIX] ApiResponse 에러일 때 상태코드도 전달, 거래내역 조회할 때 배당 join해서 프로젝트명 가져오기

### DIFF
--- a/src/main/java/com/kanghwang/khholdings/global/err/GlobalExceptionHandler.java
+++ b/src/main/java/com/kanghwang/khholdings/global/err/GlobalExceptionHandler.java
@@ -2,6 +2,7 @@ package com.kanghwang.khholdings.global.err;
 
 import org.redisson.client.RedisException;
 import org.springframework.dao.DataAccessException;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
@@ -23,22 +24,11 @@ public class GlobalExceptionHandler {
         if (message == null || message.isEmpty()) {
             message = "데이터 처리 중 문제가 발생했습니다.";
         }
-        return ResponseEntity.status(500).body(ApiResponseUtil.error(message));
+
+        return ApiResponseUtil.error(HttpStatus.INTERNAL_SERVER_ERROR, message);
     }
 
-    // 2. 그 외 모든 일반 에러 캐치
-    @ExceptionHandler(Exception.class)
-    public ResponseEntity<ApiResponse<Void>> handleGeneralError(Exception e) {
-        log.error("서버 오류 발생: {}", e.getMessage());
-        String message = e.getMessage();
-        if (message == null || message.isEmpty()) {
-            message = "서버 내부 오류가 발생했습니다.";
-        }
-
-        return ResponseEntity.status(500).body(ApiResponseUtil.error(message));
-    }
-
-    // 3. Redis 관련 에러 캐치
+    // 2. Redis 관련 에러 캐치
     @ExceptionHandler(RedisException.class)
     public ResponseEntity<ApiResponse<Void>> handleRedisError(RedisException e) {
         log.error("레디스 작업 중 오류 발생: {}", e.getMessage());
@@ -47,10 +37,10 @@ public class GlobalExceptionHandler {
             message = "레디스 작업 중 문제가 발생했습니다.";
         }
 
-        return ResponseEntity.status(500).body(ApiResponseUtil.error(message));
+        return ApiResponseUtil.error(HttpStatus.INTERNAL_SERVER_ERROR, message);
     }
 
-    // 4. 잘못된 요청 에러 캐치
+    // 3. 잘못된 요청 에러 캐치
     @ExceptionHandler(IllegalArgumentException.class)
     public ResponseEntity<ApiResponse<Void>> handleBadRequest(Exception e) {
         log.warn("잘못된 요청 발생: {}", e.getMessage());
@@ -59,6 +49,18 @@ public class GlobalExceptionHandler {
             message = "잘못된 요청입니다.";
         }
 
-        return ResponseEntity.status(400).body(ApiResponseUtil.error(message));
+        return ApiResponseUtil.error(HttpStatus.BAD_REQUEST, message);
+    }
+
+    // 4. 그 외 모든 일반 에러 캐치
+    @ExceptionHandler(Exception.class)
+    public ResponseEntity<ApiResponse<Void>> handleGeneralError(Exception e) {
+        log.error("서버 오류 발생: {}", e.getMessage());
+        String message = e.getMessage();
+        if (message == null || message.isEmpty()) {
+            message = "서버 내부 오류가 발생했습니다.";
+        }
+
+        return ApiResponseUtil.error(HttpStatus.INTERNAL_SERVER_ERROR, message);
     }
 }

--- a/src/main/java/com/kanghwang/khholdings/global/util/ApiResponseUtil.java
+++ b/src/main/java/com/kanghwang/khholdings/global/util/ApiResponseUtil.java
@@ -1,8 +1,9 @@
 package com.kanghwang.khholdings.global.util;
 
-import java.util.List;
 import java.util.Collections;
+import java.util.List;
 
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 
 import com.kanghwang.khholdings.global.dto.ApiResponse;
@@ -20,7 +21,9 @@ public class ApiResponseUtil {
 	}
 
 	// 실패
-	public static <T> ApiResponse<T> error(String message) {
-		return new ApiResponse<>(message, null);
+	public static <T> ResponseEntity<ApiResponse<T>> error(HttpStatus status, String message) {
+		return ResponseEntity
+			.status(status)
+			.body(new ApiResponse<>(message, null));
 	}
 }

--- a/src/main/resources/mapper/MyMapper.xml
+++ b/src/main/resources/mapper/MyMapper.xml
@@ -85,8 +85,8 @@
                 ELSE th.transaction_type::text
             END AS transactionType,
 
-            COALESCE(MAX(t.token_name), '-') AS tokenName,
-            COALESCE(MAX(t.ticker_symbol), '-') AS tickerSymbol,
+            COALESCE(MAX(t1.token_name), MAX(t2.token_name), '-') AS tokenName,
+            COALESCE(MAX(t1.ticker_symbol), MAX(t2.ticker_symbol), '-') AS tickerSymbol,
 
             -- executedAmount: CASH IN 이면 +, CASH OUT 이면 - 로 집계
             SUM(
@@ -125,8 +125,10 @@
             MAX(CASE WHEN th.asset_type = 'CASH' THEN th.balance_after ELSE 0 END) AS balanceAfter
 
         FROM transaction_hists th
-             LEFT JOIN orders o ON th.order_id = o.order_id
-             LEFT JOIN tokens t ON o.token_id = t.token_id
+            LEFT JOIN orders o ON th.order_id = o.order_id
+            LEFT JOIN tokens t1 ON o.token_id = t.token_id
+            LEFT JOIN dividend_hists dh ON th.transaction_id = dh.transaction_id
+            LEFT JOIN tokens t2 ON dh.token_id = t.token_id
 
         <where>
             th.wallet_id = #{walletId}


### PR DESCRIPTION
## 📌 작업 내용 요약 (Summary)
- 에러일 때 상태코드도 전달
- 서버에서 보내주는 에러 메세지 그대로 전달
- 거래내역 조회할 때 배당 join해서 프로젝트명 가져오기

## 📝 변경 사항 (Key Changes)
- [ ] ApiResponseUtil
- [ ] GlobalExceptionHandler
- [ ] MyMapper

## 📸 스크린샷 (Screenshots / Demos)
| Feature | Screenshot |
| :--- | :--- |
| 기능명 | 사진첨부 |

## 🔗 연관된 이슈 (Related Issues)
- Close #

## 🧐 주요 리뷰 포인트 (Review Point)
- 

## ✅ 최종 PR전 체크 리스트 (Checklist)
- [ ] 코딩 컨벤션(Checkstyle)을 준수하였는가?
- [ ] 불필요한 주석이나 시스템 로그(console.log, print)를 제거하였는가?
- [ ] 변경 사항에 대한 테스트를 완료하였는가?
- [ ] 관련 문서를 업데이트하였는가?
