### PR TITLE
[FIX] 매퍼에서 kh-holdings 스키마 지정했던 삭제 (public으로 옮김)

### DIFF
--- a/src/main/resources/mapper/CarbonMapper.xml
+++ b/src/main/resources/mapper/CarbonMapper.xml
@@ -17,7 +17,7 @@
             h.token_id,
             SUM(CASE WHEN w.wallet_id = #{walletId} THEN h.token_balance ELSE 0 END) as my_balance,
             SUM(CASE WHEN u.user_class = 'ENTERPRISE' THEN h.token_balance ELSE 0 END) as enterprise_total
-        FROM kh_holdings.holdings h
+        FROM holdings h
                  JOIN wallets w ON h.wallet_id = w.wallet_id
                  JOIN users u ON w.user_id = u.user_id
         GROUP BY h.token_id

--- a/src/main/resources/mapper/OrderMapper.xml
+++ b/src/main/resources/mapper/OrderMapper.xml
@@ -84,9 +84,9 @@
             (
             #{h.transactionId}, #{h.tokenId}, #{h.tradeId},
             #{h.orderId}, #{h.walletId},
-            #{h.transactionType}::kh_holdings.transaction_type_enum,
-            #{h.assetType}::kh_holdings.asset_type_enum,
-            #{h.direction}::kh_holdings.direction_enum,
+            #{h.transactionType}::transaction_type_enum,
+            #{h.assetType}::asset_type_enum,
+            #{h.direction}::direction_enum,
             #{h.amount}, #{h.balanceAfter}, #{h.remainingVolume},
             #{h.remainingPrice}, #{h.fee}, #{h.hashValue}, #{h.createdAt}
             )

--- a/src/main/resources/mapper/OrderMapper.xml
+++ b/src/main/resources/mapper/OrderMapper.xml
@@ -73,7 +73,7 @@
 
     <!-- 체결 내역 벌크 인서트 -->
     <insert id="bulkInsertTransactionHists">
-        INSERT INTO kh_holdings.transaction_hists (
+        INSERT INTO transaction_hists (
         transaction_id, token_id, trade_id,
         order_id, wallet_id, transaction_type,
         asset_type, direction, amount, balance_after,
@@ -110,7 +110,6 @@
         ON CONFLICT (token_id, candle_time, unit)
         DO UPDATE SET
             high_price = EXCLUDED.high_price,
-            low_price = EXCLUDED.low_price,
             closing_price = EXCLUDED.closing_price,
             trade_volume = EXCLUDED.trade_volume
     </insert>

--- a/src/main/resources/mapper/OrderMapper.xml
+++ b/src/main/resources/mapper/OrderMapper.xml
@@ -110,6 +110,7 @@
         ON CONFLICT (token_id, candle_time, unit)
         DO UPDATE SET
             high_price = EXCLUDED.high_price,
+            low_price = EXCLUDED.low_price,
             closing_price = EXCLUDED.closing_price,
             trade_volume = EXCLUDED.trade_volume
     </insert>


### PR DESCRIPTION
## 📌 작업 내용 요약 (Summary)
- DB를 rds에서 민제 서버로 옮기면서 기존 kh_holdings 스키마를 더이상 사용하지 않음
- 스키마 지정하면서 INSERT 했던 sql문에서 스키마 제거

## 📝 변경 사항 (Key Changes)
- [ ] CarbonMapper
- [ ] OrderMapper

## 📸 스크린샷 (Screenshots / Demos)
| Feature | Screenshot |
| :--- | :--- |
| 기능명 | 사진첨부 |

## 🔗 연관된 이슈 (Related Issues)
- Close #

## 🧐 주요 리뷰 포인트 (Review Point)
- 

## ✅ 최종 PR전 체크 리스트 (Checklist)
- [ ] 코딩 컨벤션(Checkstyle)을 준수하였는가?
- [ ] 불필요한 주석이나 시스템 로그(console.log, print)를 제거하였는가?
- [ ] 변경 사항에 대한 테스트를 완료하였는가?
- [ ] 관련 문서를 업데이트하였는가?
