### PR TITLE
[FEAT] 주문 및 주문 취소에 재시도 로직 추가

### DIFF
--- a/src/main/java/com/kanghwang/khholdings/domain/market/MarketController.java
+++ b/src/main/java/com/kanghwang/khholdings/domain/market/MarketController.java
@@ -3,7 +3,6 @@ package com.kanghwang.khholdings.domain.market;
 import java.math.BigDecimal;
 import java.util.List;
 
-import com.kanghwang.khholdings.domain.market.dto.*;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -12,7 +11,12 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
-import com.kanghwang.khholdings.domain.market.Service.MarketService;
+import com.kanghwang.khholdings.domain.market.dto.CandleDTO;
+import com.kanghwang.khholdings.domain.market.dto.OrderPriceDTO;
+import com.kanghwang.khholdings.domain.market.dto.PendingDTO;
+import com.kanghwang.khholdings.domain.market.dto.TokenListDTO;
+import com.kanghwang.khholdings.domain.market.dto.TradeDTO;
+import com.kanghwang.khholdings.domain.market.service.MarketService;
 import com.kanghwang.khholdings.global.dto.ApiResponse;
 import com.kanghwang.khholdings.global.util.ApiResponseUtil;
 

--- a/src/main/java/com/kanghwang/khholdings/domain/market/service/MarketDataService.java
+++ b/src/main/java/com/kanghwang/khholdings/domain/market/service/MarketDataService.java
@@ -1,4 +1,4 @@
-package com.kanghwang.khholdings.domain.market.Service;
+package com.kanghwang.khholdings.domain.market.service;
 
 import java.math.BigDecimal;
 import java.math.RoundingMode;
@@ -18,7 +18,7 @@ import org.springframework.stereotype.Service;
 
 import com.kanghwang.khholdings.domain.market.dto.CandleDTO;
 import com.kanghwang.khholdings.domain.market.dto.TokenListDTO;
-import com.kanghwang.khholdings.domain.order.OrderRepository;
+import com.kanghwang.khholdings.domain.order.repository.OrderRepository;
 import com.kanghwang.khholdings.domain.order.dto.TransactionRequestDTO;
 import com.kanghwang.khholdings.global.util.RedisKeyManager;
 

--- a/src/main/java/com/kanghwang/khholdings/domain/market/service/MarketService.java
+++ b/src/main/java/com/kanghwang/khholdings/domain/market/service/MarketService.java
@@ -1,4 +1,4 @@
-package com.kanghwang.khholdings.domain.market.Service;
+package com.kanghwang.khholdings.domain.market.service;
 
 import java.math.BigDecimal;
 import java.math.RoundingMode;

--- a/src/main/java/com/kanghwang/khholdings/domain/order/OrderController.java
+++ b/src/main/java/com/kanghwang/khholdings/domain/order/OrderController.java
@@ -11,6 +11,7 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+import com.kanghwang.khholdings.domain.order.dto.CancelRequestDTO;
 import com.kanghwang.khholdings.domain.order.dto.OrderRequestDTO;
 import com.kanghwang.khholdings.domain.order.service.OrderService;
 import com.kanghwang.khholdings.global.dto.ApiResponse;
@@ -55,7 +56,8 @@ public class OrderController {
 	// 주문 취소
 	@PostMapping("/cancel/{tokenId}/{orderId}")
 	public ResponseEntity<ApiResponse<Void>> cancelOrder(@PathVariable Long tokenId, @PathVariable Long orderId) {
-		orderService.cancelOrder(tokenId, orderId);
+		CancelRequestDTO cancelDTO = new CancelRequestDTO(orderId, tokenId);
+		orderService.cancelOrder(cancelDTO);
 		return ApiResponseUtil.ok("주문 취소가 완료되었습니다.", null);
 	}
 }

--- a/src/main/java/com/kanghwang/khholdings/domain/order/dto/CancelRequestDTO.java
+++ b/src/main/java/com/kanghwang/khholdings/domain/order/dto/CancelRequestDTO.java
@@ -1,0 +1,17 @@
+package com.kanghwang.khholdings.domain.order.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class CancelRequestDTO {
+	private Long orderId;
+	private Long tokenId;
+}

--- a/src/main/java/com/kanghwang/khholdings/domain/order/dto/OrderInfoDTO.java
+++ b/src/main/java/com/kanghwang/khholdings/domain/order/dto/OrderInfoDTO.java
@@ -1,0 +1,23 @@
+package com.kanghwang.khholdings.domain.order.dto;
+
+import java.math.BigDecimal;
+
+import com.kanghwang.khholdings.domain.order.type.OrderState;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class OrderInfoDTO {
+	private Long orderId;             // 주문 고유 번호
+	private OrderState orderState;    // 주문 상태
+	private BigDecimal orderVolume;   // 주문 수량
+	private BigDecimal totalPrice;    // 총 주문 금액 (시장가)
+}

--- a/src/main/java/com/kanghwang/khholdings/domain/order/dto/OrderOutboxDTO.java
+++ b/src/main/java/com/kanghwang/khholdings/domain/order/dto/OrderOutboxDTO.java
@@ -1,0 +1,26 @@
+package com.kanghwang.khholdings.domain.order.dto;
+
+import java.time.OffsetDateTime;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import lombok.ToString;
+
+@Getter
+@Setter
+@ToString
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class OrderOutboxDTO {
+	private Long orderId;    // 주문 번호 (Snowflake ID)
+	private String type;     // 주문 타입 (ORDER, CANCEL)
+	private String payload;  // 주문 또는 주문 취소 시 전달한 데이터를 텍스트로 변환한 값
+	private String status;   // 주문 상태 (PENDING, PROCESSING, PROCESSED, FAILED)
+	private int retryCount;  // 재시도 횟수 (0 ~ 5)
+	private OffsetDateTime createdAt;
+	private OffsetDateTime updatedAt;
+}

--- a/src/main/java/com/kanghwang/khholdings/domain/order/repository/OrderRepository.java
+++ b/src/main/java/com/kanghwang/khholdings/domain/order/repository/OrderRepository.java
@@ -1,4 +1,4 @@
-package com.kanghwang.khholdings.domain.order;
+package com.kanghwang.khholdings.domain.order.repository;
 
 import java.math.BigDecimal;
 import java.util.List;
@@ -6,8 +6,9 @@ import java.util.List;
 import org.apache.ibatis.annotations.Mapper;
 import org.apache.ibatis.annotations.Param;
 
-import com.kanghwang.khholdings.domain.my.dto.TransactionHistDTO;
 import com.kanghwang.khholdings.domain.market.dto.CandleDTO;
+import com.kanghwang.khholdings.domain.my.dto.TransactionHistDTO;
+import com.kanghwang.khholdings.domain.order.dto.OrderInfoDTO;
 import com.kanghwang.khholdings.domain.order.dto.OrderRequestDTO;
 import com.kanghwang.khholdings.domain.order.dto.RefundRequestDTO;
 import com.kanghwang.khholdings.domain.order.dto.SettlementResultDTO;
@@ -36,4 +37,7 @@ public interface OrderRepository {
 
 	// 1분봉 데이터 벌크 인서트
 	void insertCandlesBatch(@Param("list") List<CandleDTO> list);
+
+	// 주문 정보 조회
+	OrderInfoDTO getOrderInfoById(Long orderId);
 }

--- a/src/main/java/com/kanghwang/khholdings/domain/order/repository/OutboxRepository.java
+++ b/src/main/java/com/kanghwang/khholdings/domain/order/repository/OutboxRepository.java
@@ -1,0 +1,26 @@
+package com.kanghwang.khholdings.domain.order.repository;
+
+import java.util.List;
+
+import org.apache.ibatis.annotations.Mapper;
+
+import com.kanghwang.khholdings.domain.order.dto.OrderOutboxDTO;
+
+@Mapper
+public interface OutboxRepository {
+
+	// outbox 저장
+	void insertOutbox(Long orderId, String type, String payload, String status);
+
+	// outbox 상태 변경
+	void updateOutboxStatus(Long orderId, String type, String status, int retryCount);
+
+	// outbox 상태가 'PENDING'인 경우 변경
+	int updateStatusIfPending(Long orderId, String type, String status);
+
+	// outbox 상태를 'CANCELLED'로 변경
+	int updateStatusToCancelled(Long orderId);
+
+	// 상태가 'PENDING'이면서 가장 오래된 outbox 10개 조회
+	List<OrderOutboxDTO> findPendingOrdersForUpdate();
+}

--- a/src/main/java/com/kanghwang/khholdings/domain/order/service/OrderDBService.java
+++ b/src/main/java/com/kanghwang/khholdings/domain/order/service/OrderDBService.java
@@ -6,7 +6,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import com.kanghwang.khholdings.domain.order.OrderRepository;
+import com.kanghwang.khholdings.domain.order.repository.OrderRepository;
 import com.kanghwang.khholdings.domain.order.dto.OrderRequestDTO;
 
 @Service

--- a/src/main/java/com/kanghwang/khholdings/domain/order/service/OrderRedisService.java
+++ b/src/main/java/com/kanghwang/khholdings/domain/order/service/OrderRedisService.java
@@ -12,13 +12,17 @@ import org.redisson.api.RedissonClient;
 import org.redisson.api.stream.StreamAddArgs;
 import org.springframework.stereotype.Service;
 
-import com.kanghwang.khholdings.domain.market.Service.MarketDataService;
 import com.kanghwang.khholdings.domain.market.dto.OrderbookDTO;
 import com.kanghwang.khholdings.domain.market.dto.TradeDTO;
+import com.kanghwang.khholdings.domain.market.service.MarketDataService;
+import com.kanghwang.khholdings.domain.order.dto.CancelRequestDTO;
+import com.kanghwang.khholdings.domain.order.dto.OrderInfoDTO;
 import com.kanghwang.khholdings.domain.order.dto.OrderRequestDTO;
 import com.kanghwang.khholdings.domain.order.dto.RefundRequestDTO;
 import com.kanghwang.khholdings.domain.order.dto.TransactionRequestDTO;
+import com.kanghwang.khholdings.domain.order.repository.OrderRepository;
 import com.kanghwang.khholdings.domain.order.type.OrderSide;
+import com.kanghwang.khholdings.domain.order.type.OrderState;
 import com.kanghwang.khholdings.domain.order.type.OrderType;
 import com.kanghwang.khholdings.global.util.RedisKeyManager;
 import com.kanghwang.khholdings.global.util.SnowflakeIdGenerator;
@@ -32,6 +36,7 @@ import lombok.extern.slf4j.Slf4j;
 @RequiredArgsConstructor
 public class OrderRedisService {
 
+	private final OrderRepository orderRepository;
 	private final SnowflakeIdGenerator snowflakeIdGenerator;
 	private final RedissonClient redissonClient;
 	private final RedisKeyManager redisKeyManager;
@@ -75,6 +80,22 @@ public class OrderRedisService {
 		RScoredSortedSet<Long> myOrderBook = redissonClient.getScoredSortedSet(myOrderBookKey); // 매수(매도) 호가창 ('가격':'주문번호')
 		RScoredSortedSet<Long> counterOrderBook = redissonClient.getScoredSortedSet(counterOrderBookKey); // 매도(매수) 호가창 ('가격':'주문번호')
 		RMap<Long, OrderRequestDTO> infoMap = redissonClient.getMap(orderInfoKey); // 매수 및 매도 주문 상세 ('주문번호':'주문상세(DTO)')
+
+		// Race Condition 체크
+		// 주문이 도착하기 전에 취소 요청이 먼저 온 경우 매칭 엔진에 진입 X
+		String cancelKey = redisKeyManager.getCancelKey(myOrderId);
+		if (Boolean.TRUE.equals(redissonClient.getBucket(cancelKey).isExists())) {
+			log.warn("이미 취소 요청된 주문입니다. (ID: {})", myOrderId);
+			redissonClient.getBucket(cancelKey).delete(); // 마킹 삭제
+			return;
+		}
+
+		// 멱등성 체크
+		// 이미 처리 중이거나 처리된 주문인지 확인
+		if (infoMap.containsKey(myOrderId)) {
+			log.warn("이미 매칭 엔진에 존재하는 주문입니다. 중복 처리를 방지합니다. ID: {}", myOrderId);
+			return;
+		}
 
 		// 주문 요청 시, 호가창에 선 등록 (지정가만)
 		if (myOrderDTO.getOrderType() == OrderType.LIMIT) {
@@ -375,14 +396,45 @@ public class OrderRedisService {
 	}
 
 	// 주문 취소 (사용자가 직접)
-	public void cancelOrder(Long tokenId, Long orderId) {
+	public void cancelOrder(CancelRequestDTO cancelDto) {
+		Long tokenId = cancelDto.getTokenId();
+		Long orderId = cancelDto.getOrderId();
+
 		String orderInfoKey = redisKeyManager.getOrderInfoKey(tokenId);
 		RMap<Long, OrderRequestDTO> infoMap = redissonClient.getMap(orderInfoKey);
 
 		// 1. 주문 정보 확인
 		OrderRequestDTO orderInfo = infoMap.get(orderId);
+
 		if (orderInfo == null) {
-			throw new IllegalArgumentException("이미 취소되었거나 존재하지 않는 주문입니다.");
+			// DB에서 주문 정보를 가져오기
+			OrderInfoDTO dbOrderInfo =  orderRepository.getOrderInfoById(orderId);
+
+			// 이미 처리된 주문인 경우 종료
+			if (dbOrderInfo == null || dbOrderInfo.getOrderState() != OrderState.NEW) {
+				return;
+			}
+
+			// 취소 마킹
+			// 주문이 지연되어 뒤늦게 들어왔을 때, 취소 마킹이 있으면 매칭 엔진 진입 X
+			String cancelKey = redisKeyManager.getCancelKey(orderId);
+			redissonClient.getBucket(cancelKey).set("CANCELLED", 15, TimeUnit.MINUTES); // 유효시간 15분
+
+			log.info("매칭 엔진에 주문이 존재하지 않아 취소 마킹을 생성했습니다. (ID: {})", orderId);
+
+			// DB 정보를 바탕으로 환불 스트림 발행
+			RefundRequestDTO refundRequestDTO = new RefundRequestDTO(
+				snowflakeIdGenerator.nextId(),
+				orderId,
+				dbOrderInfo.getTotalPrice(),
+				dbOrderInfo.getOrderVolume()
+			);
+
+			redissonClient.getStream(redisKeyManager.getTradeStreamKey())
+				.add(StreamAddArgs.entry("data", refundRequestDTO));
+
+			log.info("Redis에 주문 정보가 없어 DB를 바탕으로 환불 스트림 발행 완료 (ID: {})", orderId);
+			return;
 		}
 
 		// 2. Redis 작업 (호가창 및 주문 상세에서 제거)

--- a/src/main/java/com/kanghwang/khholdings/domain/order/service/OrderService.java
+++ b/src/main/java/com/kanghwang/khholdings/domain/order/service/OrderService.java
@@ -3,12 +3,16 @@ package com.kanghwang.khholdings.domain.order.service;
 import java.math.BigDecimal;
 
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.transaction.support.TransactionSynchronization;
 import org.springframework.transaction.support.TransactionSynchronizationManager;
 
-import com.kanghwang.khholdings.domain.order.OrderRepository;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.kanghwang.khholdings.domain.order.dto.CancelRequestDTO;
 import com.kanghwang.khholdings.domain.order.dto.OrderRequestDTO;
+import com.kanghwang.khholdings.domain.order.repository.OrderRepository;
+import com.kanghwang.khholdings.domain.order.repository.OutboxRepository;
 import com.kanghwang.khholdings.domain.order.type.OrderSide;
 import com.kanghwang.khholdings.domain.order.type.OrderType;
 import com.kanghwang.khholdings.global.util.SnowflakeIdGenerator;
@@ -26,6 +30,8 @@ public class OrderService {
 	private final OrderRedisService orderRedisService;
 	private final SnowflakeIdGenerator snowflakeIdGenerator;
 	private final OrderRepository orderRepository;
+	private final OutboxRepository outboxRepository;
+	private final ObjectMapper objectMapper;
 
 	// 해당 토큰 보유 수량 조회
 	public BigDecimal selectHoldingTokenBalance(Long walletId, Long tokenId){
@@ -60,21 +66,116 @@ public class OrderService {
 			orderDTO.setRemainingToken(orderDTO.getOrderVolume());
 		}
 
-		// 3. DB에서 최소 주문 금액(수량) 확인, 자산 검증 및 동결, 주문 생성
+		// 3. DB 주문 생성 + Outbox 저장
 		orderDBService.placeOrder(orderDTO);
+		insertOutbox(orderDTO, "ORDER"); // PENDING
 
 		// 4. DB에서 주문 생성 후, Redis 매칭 엔진에 추가
 		TransactionSynchronizationManager.registerSynchronization(new TransactionSynchronization() {
 			@Override
 			public void afterCommit() {
-				log.info("매칭 엔진에 주문 추가: {}", orderDTO.getOrderId());
-				orderRedisService.processOrder(orderDTO);
+				// PENDING인 경우에만 PROCESSING으로 변경
+				// -> 리턴값이 1이면 내가 선점, 0이면 찰나의 순간에 스케줄러가 가져간 것
+				int updated = outboxRepository.updateStatusIfPending(orderDTO.getOrderId(), "ORDER", "PROCESSING");
+
+				if (updated == 1) {
+					try{
+						// Redis 전송
+						processRedisWithStatus(orderDTO, "ORDER");
+
+						// 성공 시 처리 완료 (PROCESSED)
+						updateOutboxStatus(orderId, "ORDER", "PROCESSED", 0);
+						log.info("[주문 - 실시간 처리 성공] ID: {}, count: 0", orderId);
+					} catch (Exception e) {
+						// 실패 시 대기 (PENDING)
+						updateOutboxStatus(orderId, "ORDER", "PENDING", 0);
+						log.error("[주문 - 실시간 처리 실패] ID: {}, count: 0", orderId);
+						log.error("error: {}", e.getMessage());
+					}
+				} else {
+					log.info("스케줄러가 이미 처리하고 있습니다. (ID: {}, type: ORDER)", orderDTO.getOrderId());
+				}
 			}
 		});
 	}
 
 	// 주문 취소
-	public void cancelOrder(Long tokenId, Long orderId) {
-		orderRedisService.cancelOrder(tokenId, orderId);
+	@Transactional
+	public void cancelOrder(CancelRequestDTO cancelDTO) {
+
+		// 1. 주문 outbox의 상태를 'CANCELLED'로 변경
+		outboxRepository.updateStatusToCancelled(cancelDTO.getOrderId());
+
+		// 2. 주문 취소를 outbox에 저장
+		insertOutbox(cancelDTO, "CANCEL"); // PENDING
+
+		TransactionSynchronizationManager.registerSynchronization(new TransactionSynchronization() {
+			@Override
+			public void afterCommit() {
+				// 2. 선점 시도
+				int updated = outboxRepository.updateStatusIfPending(cancelDTO.getOrderId(), "CANCEL", "PROCESSING");
+
+				// 3. 상태가 'PENDING'인 경우 취소
+				if (updated == 1) {
+					Long orderId = cancelDTO.getOrderId();
+
+					try {
+						// Stream 전송
+						processRedisWithStatus(cancelDTO, "CANCEL");
+
+						// 성공 시 처리 완료 (PROCESSED)
+						updateOutboxStatus(orderId, "CANCEL", "PROCESSED", 0);
+						log.info("[취소 - 실시간 처리 성공] ID: {}, count: 0", orderId);
+					} catch (Exception e) {
+						// 실패 시 대기 (PENDING)
+						updateOutboxStatus(orderId, "CANCEL", "PENDING", 0);
+						log.error("[취소 - 실시간 처리 실패] ID: {}, count: 0", orderId);
+						log.error("error: {}", e.getMessage());
+					}
+				} else {
+					log.info("스케줄러가 이미 처리하고 있습니다. (ID: {}, type: CANCEL)", cancelDTO.getOrderId());
+				}
+			}
+		});
+	}
+
+	// 요청 전송
+	public void processRedisWithStatus(Object dto, String type) throws Exception {
+		if ("ORDER".equals(type)) {
+			OrderRequestDTO orderDto = (OrderRequestDTO) dto;
+			orderRedisService.processOrder(orderDto);
+		} else if ("CANCEL".equals(type)) {
+			CancelRequestDTO cancelDto = (CancelRequestDTO) dto;
+			orderRedisService.cancelOrder(cancelDto);
+		}
+	}
+
+	// outbox 입력
+	private void insertOutbox(Object dto, String type) {
+		try {
+			Long orderId = 0L;
+			String json = "";
+
+			if ("ORDER".equals(type)) {
+				OrderRequestDTO orderDto = (OrderRequestDTO) dto;
+				orderId = orderDto.getOrderId();
+				json = objectMapper.writeValueAsString(orderDto);
+			} else if ("CANCEL".equals(type)) {
+				CancelRequestDTO cancelDto = (CancelRequestDTO) dto;
+				orderId = cancelDto.getOrderId();
+				json = objectMapper.writeValueAsString(cancelDto);
+			}
+
+			outboxRepository.insertOutbox(orderId, type, json, "PENDING");
+			log.info("Outbox 저장 성공 (ID: {}, type: {})", orderId, type);
+		} catch (Exception e) {
+			throw new RuntimeException("Outbox 저장 실패", e);
+		}
+	}
+
+	// 별도 트랜잭션으로 상태 즉시 업데이트
+	@Transactional(propagation = Propagation.REQUIRES_NEW)
+	public void updateOutboxStatus(Long orderId, String type, String status, int retryCount) {
+		outboxRepository.updateOutboxStatus(orderId, type, status, retryCount);
 	}
 }

--- a/src/main/java/com/kanghwang/khholdings/domain/order/worker/RetryWorker.java
+++ b/src/main/java/com/kanghwang/khholdings/domain/order/worker/RetryWorker.java
@@ -1,0 +1,63 @@
+package com.kanghwang.khholdings.domain.order.worker;
+
+import java.util.List;
+
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.kanghwang.khholdings.domain.order.dto.CancelRequestDTO;
+import com.kanghwang.khholdings.domain.order.dto.OrderOutboxDTO;
+import com.kanghwang.khholdings.domain.order.dto.OrderRequestDTO;
+import com.kanghwang.khholdings.domain.order.repository.OutboxRepository;
+import com.kanghwang.khholdings.domain.order.service.OrderService;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class RetryWorker {
+	private final OutboxRepository outboxRepository;
+	private final OrderService orderService;
+	private final ObjectMapper objectMapper;
+
+	@Scheduled(fixedDelay = 10000) // 10초
+	public void retryFailedOrders() {
+		// 1. PENDING 상태인 것들만 긁어옴 (SKIP LOCKED로 동시성 확보)
+		List<OrderOutboxDTO> pendings = outboxRepository.findPendingOrdersForUpdate();
+
+		for (OrderOutboxDTO outbox : pendings) {
+			Long orderId = outbox.getOrderId();
+			String type = outbox.getType(); // ORDER, CANCEL
+			String typeKR = ("ORDER").equals(type) ? "주문" : "취소";
+			int curRetry = outbox.getRetryCount();
+			int nextRetry = curRetry + 1;
+			String nextStatus = (nextRetry >= 5) ? "FAILED" : "PENDING";
+
+			try {
+				// 2. 즉시 PROCESSING으로 변경하여 다른 스레드 접근 차단 (트랜잭션 분리 권장)
+				orderService.updateOutboxStatus(orderId, type, "PROCESSING", curRetry);
+
+				// 3. json을 DTO로 변환하여 재시도 준비
+				Object dto = ("ORDER".equals(type))
+					? objectMapper.readValue(outbox.getPayload(), OrderRequestDTO.class)   // 주문 (ORDER)
+					: objectMapper.readValue(outbox.getPayload(), CancelRequestDTO.class); // 취소 (CANCEL)
+
+				// 4. 공통 전송 메서드 호출
+				orderService.processRedisWithStatus(dto, type);
+
+				// 성공 시 처리 완료 (PROCESSED)
+				orderService.updateOutboxStatus(orderId, type, "PROCESSED", curRetry);
+				log.info("[{} - 재시도 성공] ID: {}, count: {}", typeKR, orderId, curRetry);
+			} catch (Exception e) {
+				// 실패 시 재시도 횟수에 따라 상태 변경 (FAILED or PENDING)
+				// -> 이후 스케줄러가 잡아 처리
+				orderService.updateOutboxStatus(orderId, type, nextStatus, nextRetry);
+				log.error("[{} - 재시도 실패] ID: {}, count: {}", typeKR, orderId, curRetry);
+				log.error("error: {}", e.getMessage());
+			}
+		}
+	}
+}

--- a/src/main/java/com/kanghwang/khholdings/domain/order/worker/TradeWorker.java
+++ b/src/main/java/com/kanghwang/khholdings/domain/order/worker/TradeWorker.java
@@ -1,4 +1,4 @@
-package com.kanghwang.khholdings.domain.order;
+package com.kanghwang.khholdings.domain.order.worker;
 
 import java.math.BigDecimal;
 import java.math.RoundingMode;
@@ -29,6 +29,7 @@ import com.kanghwang.khholdings.domain.my.dto.TransactionHistDTO;
 import com.kanghwang.khholdings.domain.order.dto.RefundRequestDTO;
 import com.kanghwang.khholdings.domain.order.dto.SettlementResultDTO;
 import com.kanghwang.khholdings.domain.order.dto.TransactionRequestDTO;
+import com.kanghwang.khholdings.domain.order.repository.OrderRepository;
 import com.kanghwang.khholdings.global.util.RedisKeyManager;
 
 import jakarta.annotation.PreDestroy;

--- a/src/main/java/com/kanghwang/khholdings/global/util/RedisKeyManager.java
+++ b/src/main/java/com/kanghwang/khholdings/global/util/RedisKeyManager.java
@@ -66,4 +66,9 @@ public class RedisKeyManager {
     public String getCandleKey(Long tokenId, int unit, Long timestamp) {
         return getPrefix() + "candle:" + unit + "m:" + tokenId + ":" + timestamp;
     }
+
+    // 11. 취소 주문 정보
+    public String getCancelKey(Long orderId) {
+        return getPrefix() + "cancel:mark:" + orderId;
+    }
 }

--- a/src/main/resources/mapper/OrderMapper.xml
+++ b/src/main/resources/mapper/OrderMapper.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
 
-<mapper namespace="com.kanghwang.khholdings.domain.order.OrderRepository">
+<mapper namespace="com.kanghwang.khholdings.domain.order.repository.OrderRepository">
 
     <!-- 특정 토큰 보유 수량 조회 -->
     <select id="selectHoldingTokenBalance" parameterType="Long" resultType="bigdecimal">
@@ -113,4 +113,15 @@
             closing_price = EXCLUDED.closing_price,
             trade_volume = EXCLUDED.trade_volume
     </insert>
+
+    <!--  주문 정보 조회  -->
+    <select id="getOrderInfoById" resultType="OrderInfoDTO">
+        SELECT
+            order_id,
+            order_state,
+            order_volume,
+            total_price
+        FROM orders
+        WHERE order_id = #{orderId}
+    </select>
 </mapper>

--- a/src/main/resources/mapper/OutboxMapper.xml
+++ b/src/main/resources/mapper/OutboxMapper.xml
@@ -1,0 +1,61 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+
+<mapper namespace="com.kanghwang.khholdings.domain.order.repository.OutboxRepository">
+    <insert id="insertOutbox">
+        INSERT INTO order_outbox (
+            order_id,
+            type,
+            payload,
+            status,
+            retry_count,
+            created_at,
+            updated_at
+        ) VALUES (
+            #{orderId},
+            #{type},
+            #{payload},
+            #{status},
+            0,
+            NOW(),
+            NOW()
+        )
+    </insert>
+
+    <update id="updateOutboxStatus">
+        UPDATE order_outbox
+        SET
+            status = #{status},
+            retry_count = #{retryCount},
+            updated_at = NOW()
+        WHERE order_id = #{orderId}
+            AND type = #{type}
+    </update>
+
+    <update id="updateStatusIfPending">
+        UPDATE order_outbox
+        SET
+            status = #{status},
+            updated_at = NOW()
+        WHERE order_id = #{orderId}
+            AND type = #{type}
+            AND status = 'PENDING'
+    </update>
+
+    <update id="updateStatusToCancelled">
+        UPDATE order_outbox
+        SET status = 'CANCELLED'
+        WHERE order_id = #{orderId}
+          AND type = 'ORDER'
+          AND status IN ('PENDING', 'PROCESSING');
+    </update>
+
+    <select id="findPendingOrdersForUpdate" resultType="OrderOutboxDTO">
+        SELECT * FROM order_outbox
+        WHERE status = 'PENDING'
+          AND retry_count <![CDATA[ < ]]> 5
+        ORDER BY created_at ASC
+            LIMIT 10
+        FOR UPDATE SKIP LOCKED
+    </select>
+</mapper>

--- a/src/test/java/com/kanghwang/khholdings/order/OrderServiceTest.java
+++ b/src/test/java/com/kanghwang/khholdings/order/OrderServiceTest.java
@@ -1,7 +1,7 @@
 //package com.kanghwang.khholdings.order;
 //
 //import com.kanghwang.khholdings.domain.market.MarketRepository;
-//import com.kanghwang.khholdings.domain.order.OrderRepository;
+//import com.kanghwang.khholdings.domain.order.repository.OrderRepository;
 //import com.kanghwang.khholdings.domain.order.service.OrderService;
 //import com.kanghwang.khholdings.domain.order.dto.OrderRequestDTO;
 //import com.kanghwang.khholdings.domain.order.type.OrderSide;


### PR DESCRIPTION
## 📌 작업 내용 요약 (Summary)
- 주문 및 주문 취소에 재시도 로직 추가 (스케줄러 활용)
- 주문과 주문 취소의 race condition을 해결 (Redis Map 활용)
- order_outbox 테이블 추가
- domain/order에 repository와 worker 폴더 추가

## 📝 변경 사항 (Key Changes)
- [ ] OrderService
- [ ] OrderRedisService
- [ ] RetryWorker

## 📸 스크린샷 (Screenshots / Demos)
| Feature | Screenshot |
| :--- | :--- |
| order_outbox 테이블 | <img width="992" height="162" alt="image" src="https://github.com/user-attachments/assets/c18f6506-ee74-4ae6-af07-98f8b2cfe993" /> |

## 🔗 연관된 이슈 (Related Issues)
- Close #

## 🧐 주요 리뷰 포인트 (Review Point)
- 

## ✅ 최종 PR전 체크 리스트 (Checklist)
- [ ] 코딩 컨벤션(Checkstyle)을 준수하였는가?
- [ ] 불필요한 주석이나 시스템 로그(console.log, print)를 제거하였는가?
- [ ] 변경 사항에 대한 테스트를 완료하였는가?
- [ ] 관련 문서를 업데이트하였는가?
