### PR TITLE
[FIX] 매수 매도 동시에 불가하도록 막기

### DIFF
--- a/src/main/java/com/kanghwang/khholdings/domain/order/service/OrderRedisService.java
+++ b/src/main/java/com/kanghwang/khholdings/domain/order/service/OrderRedisService.java
@@ -85,7 +85,7 @@ public class OrderRedisService {
 		// 주문이 도착하기 전에 취소 요청이 먼저 온 경우 매칭 엔진에 진입 X
 		String cancelKey = redisKeyManager.getCancelKey(myOrderId);
 		if (Boolean.TRUE.equals(redissonClient.getBucket(cancelKey).isExists())) {
-			log.warn("이미 취소 요청된 주문입니다. (ID: {})", myOrderId);
+			log.warn("[EXIT] 이미 취소 요청된 주문입니다. (ID: {})", myOrderId);
 			redissonClient.getBucket(cancelKey).delete(); // 마킹 삭제
 			return;
 		}
@@ -93,7 +93,7 @@ public class OrderRedisService {
 		// 멱등성 체크
 		// 이미 처리 중이거나 처리된 주문인지 확인
 		if (infoMap.containsKey(myOrderId)) {
-			log.warn("이미 매칭 엔진에 존재하는 주문입니다. 중복 처리를 방지합니다. ID: {}", myOrderId);
+			log.warn("[EXIT] 이미 매칭 엔진에 존재하는 주문입니다. (ID: {})", myOrderId);
 			return;
 		}
 
@@ -126,7 +126,7 @@ public class OrderRedisService {
 			} else {
 				if (myOrderDTO.getRemainingToken().compareTo(BigDecimal.ZERO) <= 0) {
 					// 2) 그 외(지정가, 시장가 매도) : 미체결 수량이 0보다 작거나 같으면 break
-					log.info("[EXIT] 전액 체결로 매칭을 종료합니다.");
+					log.info("[EXIT] 전량 체결로 매칭을 종료합니다.");
 					break;
 				}
 			}
@@ -175,7 +175,9 @@ public class OrderRedisService {
 			// 주문 상세에서 상대방의 주문 정보를 가져옴
 			OrderRequestDTO targetOrderDTO = infoMap.get(targetOrderId);
 			if (targetOrderDTO == null) {
-				// 주문 상세에 상대방의 주문 정보가 없으면 해당 주문 제거 후, 다음 상대방 찾기 (continue)
+				// 주문 상세에 상대방의 주문 정보가 없으면 해당 주문 제거 및 미체결 수량 해제 후, 다음 상대방 찾기 (continue)
+				log.error("[CRITICAL] 주문이 호가창에는 존재하나 상세정보가 없습니다. (ID: {})", targetOrderId);
+				// releaseOrderQty(targetOrderDTO.getWalletId(), targetOrderDTO.getTokenId(), targetOrderDTO.getOrderVolume(), counterSide);
 				removeOrder(myOrderDTO.getTokenId(), counterSide, targetOrderId);
 				continue;
 			}
@@ -253,8 +255,8 @@ public class OrderRedisService {
 			// (3) 토큰 실시간 리스트 제작, 캔들 생성
 			marketDataService.processMarketUpdate(transactionDTO);
 
-			log.info("체결: Price {}, Volume {}, Amount {}", targetPrice.toPlainString(), executedVolume.toPlainString(), executedAmount.toPlainString());
-			log.info("Worker에게 나머지 작업 전달: TradeID {}", tradeId);
+			log.info("[체결] Price {}, Volume {}, Amount {}", targetPrice.toPlainString(), executedVolume.toPlainString(), executedAmount.toPlainString());
+			log.info("[정산 예약] TradeID {}", tradeId);
 
 			// [Step 4] 자산 정산 (미체결 수량 및 금액 갱신)
 			// 1) 나
@@ -286,8 +288,9 @@ public class OrderRedisService {
 			updateAggrOrderBook(tokenId, counterSide, targetPrice, executedVolume.negate());
 
 			if (targetOrderDTO.getRemainingToken().compareTo(BigDecimal.ZERO) <= 0) {
-				// 1) 0보다 작거나 같으면, 해당 주문을 호가창에서 제거 (매칭 X)
-				log.info("주문 전량 체결 완료: OrderId {}", targetOrderId);
+				// 1) 0보다 작거나 같으면, 해당 주문의 미체결 수량을 해제하고 호가창에서 제거 (매칭 X)
+				log.info("[전체 체결] OrderId {}", targetOrderId);
+				releaseOrderQty(targetOrderDTO.getWalletId(), targetOrderDTO.getTokenId(), targetOrderDTO.getOrderVolume(), counterSide);
 				removeOrder(myOrderDTO.getTokenId(), counterSide, targetOrderId);
 			} else {
 				// 2) 0보다 크면, 주문 상세 업데이트
@@ -324,11 +327,12 @@ public class OrderRedisService {
 				RefundRequestDTO refundRequestDTO = new RefundRequestDTO(snowflakeIdGenerator.nextId(), myOrderDTO.getOrderId(), myOrderDTO.getRemainingCash(), BigDecimal.ZERO);
 				redissonClient.getStream(redisKeyManager.getTradeStreamKey())
 					.add(StreamAddArgs.entry("data", refundRequestDTO));
-				log.info("지정가 매수 차액 환불: 주문ID {}, 환불금액 {}", myOrderDTO.getOrderId(), myOrderDTO.getRemainingCash());
+				log.info("[지정가 매수 - 차액 환불] 주문ID {}, 환불금액 {}", myOrderDTO.getOrderId(), myOrderDTO.getRemainingCash());
 			}
 
-			// 체결 완료 시, 호가창과 상세 정보에서 제거
-			log.info("주문 전량 체결 완료: OrderId {}", myOrderDTO.getOrderId());
+			// 체결 완료 시 미체결 수량 해제 및 상세 정보에서 제거
+			log.info("[전체 체결] OrderId {}", myOrderDTO.getOrderId());
+			releaseOrderQty(myOrderDTO.getWalletId(), myOrderDTO.getTokenId(), myOrderDTO.getOrderVolume(), mySide);
 			removeOrder(myOrderDTO.getTokenId(), mySide, myOrderDTO.getOrderId());
 		} else {
 			// 부분 체결 시,
@@ -339,11 +343,12 @@ public class OrderRedisService {
 				redissonClient.getStream(redisKeyManager.getTradeStreamKey())
 					.add(StreamAddArgs.entry("data", refundRequestDTO));
 
-				log.info("시장가 주문 매칭 종료로 잔량 환불: OrderId {}", myOrderDTO.getOrderId());
+				log.info("[시장가 주문 - 잔량 환불] OrderId {}", myOrderDTO.getOrderId());
+				releaseOrderQty(myOrderDTO.getWalletId(), myOrderDTO.getTokenId(), myOrderDTO.getOrderVolume(), mySide);
 				removeOrder(myOrderDTO.getTokenId(), mySide, myOrderDTO.getOrderId());
 			} else {
 				// 2) 지정가 주문은 이미 [Step 5]에서 업데이트
-				log.info("지정가 주문 잔량 대기: OrderId {}, RemainingToken {}", myOrderDTO.getOrderId(), myOrderDTO.getRemainingToken());
+				log.info("[지정가 주문 - 잔량 대기] OrderId {}, RemainingToken {}", myOrderDTO.getOrderId(), myOrderDTO.getRemainingToken());
 			}
 		}
 	}
@@ -385,6 +390,19 @@ public class OrderRedisService {
 		redissonClient.getTopic(orderbookAggrKey).publish(orderbookDTO);
 	}
 
+	// 미체결 수량 차감
+	private void releaseOrderQty(Long walletId, Long tokenId, BigDecimal volume, OrderSide side) {
+		String key = redisKeyManager.getPersonalOrderBookKey(walletId, side);
+		RMap<Long, BigDecimal> myOrderMap = redissonClient.getMap(key);
+
+		myOrderMap.compute(tokenId, (k, v) -> {
+			if (v == null) return null;
+			BigDecimal result = v.subtract(volume);
+			return (result.compareTo(BigDecimal.ZERO) <= 0) ? null : result;
+		});
+		log.info("[미체결 수량 해제] Wallet: {}, Token: {}, Side: {}, Volume: {}", walletId, tokenId, side, volume);
+	}
+
 	// 호가창 및 주문 상세에서 주문 제거
 	public void removeOrder(Long tokenId, OrderSide side, Long orderId) {
 		String bookKey = redisKeyManager.getOrderBookKey(tokenId, side);
@@ -420,7 +438,7 @@ public class OrderRedisService {
 			String cancelKey = redisKeyManager.getCancelKey(orderId);
 			redissonClient.getBucket(cancelKey).set("CANCELLED", 15, TimeUnit.MINUTES); // 유효시간 15분
 
-			log.info("매칭 엔진에 주문이 존재하지 않아 취소 마킹을 생성했습니다. (ID: {})", orderId);
+			log.info("[EXIT] 매칭 엔진에 주문이 존재하지 않아 취소 마킹을 생성했습니다. (ID: {})", orderId);
 
 			// DB 정보를 바탕으로 환불 스트림 발행
 			RefundRequestDTO refundRequestDTO = new RefundRequestDTO(
@@ -433,11 +451,12 @@ public class OrderRedisService {
 			redissonClient.getStream(redisKeyManager.getTradeStreamKey())
 				.add(StreamAddArgs.entry("data", refundRequestDTO));
 
-			log.info("Redis에 주문 정보가 없어 DB를 바탕으로 환불 스트림 발행 완료 (ID: {})", orderId);
+			log.info("[EXIT] Redis에 주문 정보가 없어 DB를 바탕으로 환불 스트림 발행했습니다. (ID: {})", orderId);
 			return;
 		}
 
-		// 2. Redis 작업 (호가창 및 주문 상세에서 제거)
+		// 2. Redis 작업 (미체결 수량 해제 및 호가창, 상세 정보에서 제거)
+		releaseOrderQty(orderInfo.getWalletId(), orderInfo.getTokenId(), orderInfo.getOrderVolume(), orderInfo.getOrderSide());
 		removeOrder(orderInfo.getTokenId(), orderInfo.getOrderSide(), orderId);
 		updateAggrOrderBook(orderInfo.getTokenId(), orderInfo.getOrderSide(), orderInfo.getOrderPrice(), orderInfo.getRemainingToken().negate());
 
@@ -452,6 +471,6 @@ public class OrderRedisService {
 		redissonClient.getStream(redisKeyManager.getTradeStreamKey())
 			.add(StreamAddArgs.entry("data", refundRequestDTO));
 
-		log.info("TradeWorker에 주문 취소 요청: OrderId {}", orderId);
+		log.info("[주문 취소 예약] OrderId {}", orderId);
 	}
 }

--- a/src/main/java/com/kanghwang/khholdings/domain/order/service/OrderService.java
+++ b/src/main/java/com/kanghwang/khholdings/domain/order/service/OrderService.java
@@ -2,6 +2,8 @@ package com.kanghwang.khholdings.domain.order.service;
 
 import java.math.BigDecimal;
 
+import org.redisson.api.RMap;
+import org.redisson.api.RedissonClient;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
@@ -15,6 +17,7 @@ import com.kanghwang.khholdings.domain.order.repository.OrderRepository;
 import com.kanghwang.khholdings.domain.order.repository.OutboxRepository;
 import com.kanghwang.khholdings.domain.order.type.OrderSide;
 import com.kanghwang.khholdings.domain.order.type.OrderType;
+import com.kanghwang.khholdings.global.util.RedisKeyManager;
 import com.kanghwang.khholdings.global.util.SnowflakeIdGenerator;
 
 import lombok.RequiredArgsConstructor;
@@ -25,13 +28,13 @@ import lombok.extern.slf4j.Slf4j;
 @RequiredArgsConstructor
 public class OrderService {
 
-	private final SnowflakeIdGenerator idGenerator;
 	private final OrderDBService orderDBService;
 	private final OrderRedisService orderRedisService;
 	private final SnowflakeIdGenerator snowflakeIdGenerator;
-	private final OrderRepository orderRepository;
 	private final OutboxRepository outboxRepository;
 	private final ObjectMapper objectMapper;
+	private final RedissonClient redissonClient;
+	private final RedisKeyManager redisKeyManager;
 
 	// 해당 토큰 보유 수량 조회
 	public BigDecimal selectHoldingTokenBalance(Long walletId, Long tokenId){
@@ -46,57 +49,91 @@ public class OrderService {
 	// 매수/매도 주문
 	@Transactional
 	public void placeOrder(OrderRequestDTO orderDTO) {
+		// 1. 반대 방향 주문이 있는지 확인 (ex. 매수가 있으면 매도 불가)
+		OrderSide mySide = orderDTO.getOrderSide();
+		OrderSide oppositeSide = mySide.equals(OrderSide.BUY) ? OrderSide.SELL : OrderSide.BUY;
 
-		// 1. Snowflake ID를 사용하여 주문 번호 생성
-		Long orderId = snowflakeIdGenerator.nextId();
-		orderDTO.setOrderId(orderId);
+		// 내 반대 방향 주문 정보를 얻기 위한 키
+		String myOppositeKey = redisKeyManager.getPersonalOrderBookKey(orderDTO.getWalletId(), oppositeSide);
+		// 내 현재 방향 주문 정보를 얻기 위한 키
+		String myCurrentKey = redisKeyManager.getPersonalOrderBookKey(orderDTO.getWalletId(), mySide);
 
-		// 2. 주문 요청 시, 미체결 금액 및 미체결 수량 초기화
-		// 1) 미체결 금액: 매수(BUY)는 총 주문 금액으로, 매도(SELL)은 0으로 초기화
-		if (orderDTO.getOrderSide() == OrderSide.BUY) {
-			orderDTO.setRemainingCash(orderDTO.getTotalPrice());
-		} else {
-			orderDTO.setRemainingCash(BigDecimal.ZERO);
+		RMap<Long, BigDecimal> myOppositeMap = redissonClient.getMap(myOppositeKey); // 주문 정보 <토큰 ID: 수량>
+		RMap<Long, BigDecimal> myCurrentMap = redissonClient.getMap(myCurrentKey);
+
+		BigDecimal myOppositeQty = myOppositeMap.get(orderDTO.getTokenId());
+		if (myOppositeQty != null && myOppositeQty.compareTo(BigDecimal.ZERO) > 0) {
+			String sideKr = "매수";
+			if (oppositeSide.equals(OrderSide.SELL)) sideKr = "매도";
+			throw new RuntimeException("[주문 실패] " + sideKr + " 미체결 수량 존재");
 		}
 
-		// 2) 미체결 수량: 시장가 매수(MARKET, BUY)는 0으로, 그 외는 총 주문 수량으로 초기화
-		if (orderDTO.getOrderType() == OrderType.MARKET && orderDTO.getOrderSide() == OrderSide.BUY) {
-			orderDTO.setRemainingToken(BigDecimal.ZERO);
-		} else {
-			orderDTO.setRemainingToken(orderDTO.getOrderVolume());
-		}
+		// 반대 방향 주문이 없으면 현재 방향에 수량 추가
+		BigDecimal volume = orderDTO.getOrderVolume();
+		myCurrentMap.compute(orderDTO.getTokenId(), (k, v) -> (v == null) ? volume : v.add(volume));
 
-		// 3. DB 주문 생성 + Outbox 저장
-		orderDBService.placeOrder(orderDTO);
-		insertOutbox(orderDTO, "ORDER"); // PENDING
+		try {
 
-		// 4. DB에서 주문 생성 후, Redis 매칭 엔진에 추가
-		TransactionSynchronizationManager.registerSynchronization(new TransactionSynchronization() {
-			@Override
-			public void afterCommit() {
-				// PENDING인 경우에만 PROCESSING으로 변경
-				// -> 리턴값이 1이면 내가 선점, 0이면 찰나의 순간에 스케줄러가 가져간 것
-				int updated = outboxRepository.updateStatusIfPending(orderDTO.getOrderId(), "ORDER", "PROCESSING");
+			// 2. Snowflake ID를 사용하여 주문 번호 생성
+			Long orderId = snowflakeIdGenerator.nextId();
+			orderDTO.setOrderId(orderId);
 
-				if (updated == 1) {
-					try{
-						// Redis 전송
-						processRedisWithStatus(orderDTO, "ORDER");
-
-						// 성공 시 처리 완료 (PROCESSED)
-						updateOutboxStatus(orderId, "ORDER", "PROCESSED", 0);
-						log.info("[주문 - 실시간 처리 성공] ID: {}, count: 0", orderId);
-					} catch (Exception e) {
-						// 실패 시 대기 (PENDING)
-						updateOutboxStatus(orderId, "ORDER", "PENDING", 0);
-						log.error("[주문 - 실시간 처리 실패] ID: {}, count: 0", orderId);
-						log.error("error: {}", e.getMessage());
-					}
-				} else {
-					log.info("스케줄러가 이미 처리하고 있습니다. (ID: {}, type: ORDER)", orderDTO.getOrderId());
-				}
+			// 3. 미체결 금액 및 미체결 수량 초기화
+			// 1) 미체결 금액: 매수(BUY)는 총 주문 금액으로, 매도(SELL)은 0으로 초기화
+			if (orderDTO.getOrderSide() == OrderSide.BUY) {
+				orderDTO.setRemainingCash(orderDTO.getTotalPrice());
+			} else {
+				orderDTO.setRemainingCash(BigDecimal.ZERO);
 			}
-		});
+
+			// 2) 미체결 수량: 시장가 매수(MARKET, BUY)는 0으로, 그 외는 총 주문 수량으로 초기화
+			if (orderDTO.getOrderType() == OrderType.MARKET && orderDTO.getOrderSide() == OrderSide.BUY) {
+				orderDTO.setRemainingToken(BigDecimal.ZERO);
+			} else {
+				orderDTO.setRemainingToken(orderDTO.getOrderVolume());
+			}
+
+			// 4. DB 주문 생성 + Outbox 저장
+			orderDBService.placeOrder(orderDTO);
+			insertOutbox(orderDTO, "ORDER"); // PENDING
+
+			// 5. DB에서 주문 생성 후, Redis 매칭 엔진에 추가
+			TransactionSynchronizationManager.registerSynchronization(new TransactionSynchronization() {
+				@Override
+				public void afterCommit() {
+					// PENDING인 경우에만 PROCESSING으로 변경
+					// -> 리턴값이 1이면 내가 선점, 0이면 찰나의 순간에 스케줄러가 가져간 것
+					int updated = outboxRepository.updateStatusIfPending(orderDTO.getOrderId(), "ORDER", "PROCESSING");
+
+					if (updated == 1) {
+						try{
+							// Redis 전송
+							processRedisWithStatus(orderDTO, "ORDER");
+
+							// 성공 시 처리 완료 (PROCESSED)
+							updateOutboxStatus(orderId, "ORDER", "PROCESSED", 0);
+							log.info("[주문 - 실시간 처리 성공] ID: {}, count: 0", orderId);
+						} catch (Exception e) {
+							// 실패 시 대기 (PENDING)
+							updateOutboxStatus(orderId, "ORDER", "PENDING", 0);
+							log.error("[주문 - 실시간 처리 실패] ID: {}, count: 0", orderId);
+							log.error("error: {}", e.getMessage());
+						}
+					} else {
+						log.info("스케줄러가 이미 처리하고 있습니다. (ID: {}, type: ORDER)", orderDTO.getOrderId());
+					}
+				}
+			});
+		} catch (Exception e) {
+			// DB 작업 실패 시 현재 방향 주문 정보에 더했던 수량 차감
+			myCurrentMap.compute(orderDTO.getTokenId(), (k, v) -> {
+				if (v == null) return null;
+				BigDecimal result = v.subtract(volume);
+				return (result.compareTo(BigDecimal.ZERO) <= 0) ? null : result;
+			});
+			log.error("DB 주문 생성 실패로 인한 Redis 수량 롤백 완료");
+			throw e; // 예외를 다시 던져서 @Transactional 롤백 유도
+		}
 	}
 
 	// 주문 취소

--- a/src/main/java/com/kanghwang/khholdings/domain/order/worker/TradeWorker.java
+++ b/src/main/java/com/kanghwang/khholdings/domain/order/worker/TradeWorker.java
@@ -65,10 +65,13 @@ public class TradeWorker implements CommandLineRunner {
         this.isRunning = false;
         log.info("[TradeWorker] 종료 신호를 받았습니다. 현재 처리중인 작업을 마치고 종료합니다.");
         try {
-            // 워커 스레드가 latch.countDown()을 호출할 때까지 최대 5초간 대기
+            // 1. 워커 스레드가 latch.countDown()을 호출할 때까지 최대 5초간 대기
             if (!shutdownLatch.await(5, TimeUnit.SECONDS)) {
                 log.warn("[TradeWorker] 워커가 5초 내에 종료되지 않아 강제 진행합니다.");
             }
+
+            // 2. 큐에 남아있는 모든 잔여 데이터를 DB에 강제 저장
+            forceFlushAll();
         } catch (InterruptedException e) {
             Thread.currentThread().interrupt();
         }
@@ -87,33 +90,36 @@ public class TradeWorker implements CommandLineRunner {
                 Map<StreamMessageId, Map<String, Object>> messages = stream.read(
                         StreamReadArgs.greaterThan(lastId).count(10).timeout(Duration.ofSeconds(1)));
 
-                // 데이터가 없으면 건너뛰기
-                if (messages == null || messages.isEmpty()) {
-                    continue;
+                // 데이터가 없는데 종료 신호가 왔다면 종료
+                if ((messages == null || messages.isEmpty()) && !isRunning) {
+                    break;
                 }
 
-                for (Map.Entry<StreamMessageId, Map<String, Object>> entry : messages.entrySet()) {
-                    StreamMessageId currentId = entry.getKey(); // 현재 처리 중인 메시지의 ID
-                    Object data = entry.getValue().get("data");
+                // 데이터가 있다면 종료 신호와 상관없이 처리
+                if (messages != null) {
+                    for (Map.Entry<StreamMessageId, Map<String, Object>> entry : messages.entrySet()) {
+                        StreamMessageId currentId = entry.getKey(); // 현재 처리 중인 메시지의 ID
+                        Object data = entry.getValue().get("data");
 
-                    try {
-                        // [1] 데이터 처리 로직
-                        if (data instanceof TransactionRequestDTO transactionDTO) {
-                            // 1. 체결 정산 처리
-                            handleTransaction(transactionDTO);
-                        } else if (data instanceof RefundRequestDTO refundDTO) {
-                            // 2. 취소 및 환불 처리
-                            handleRefund(refundDTO);
+                        try {
+                            // [1] 데이터 처리 로직
+                            if (data instanceof TransactionRequestDTO transactionDTO) {
+                                // 1. 체결 정산 처리
+                                handleTransaction(transactionDTO);
+                            } else if (data instanceof RefundRequestDTO refundDTO) {
+                                // 2. 취소 및 환불 처리
+                                handleRefund(refundDTO);
+                            }
+
+                            // [2] 처리가 성공하면 즉시 해당 메시지 삭제
+                            stream.remove(currentId);
+
+                            // [3] 다음 읽기 지점을 현재 메시지 이후로 업데이트
+                            lastId = currentId;
+
+                        } catch (Exception e) {
+                            log.error("[TradeWorker] 정산 처리 중 오류 발생: ", e);
                         }
-
-                        // [2] 처리가 성공하면 즉시 해당 메시지 삭제
-                        stream.remove(currentId);
-
-                        // [3] 다음 읽기 지점을 현재 메시지 이후로 업데이트
-                        lastId = currentId;
-
-                    } catch (Exception e) {
-                        log.error("[TradeWorker] 정산 처리 중 오류 발생: ", e);
                     }
                 }
             } catch (Exception e) {
@@ -195,24 +201,41 @@ public class TradeWorker implements CommandLineRunner {
                 .hashValue(txId + "_" + tradeId).createdAt(time).build();
     }
 
-    // [DB] 1초마다 혹은 버퍼가 차면 DB에 한 번에 저장
+    // 1초마다 혹은 버퍼 비우기
     @Scheduled(fixedDelay = 1000)
-    public void periodFlush() {
-
-        if (transactionBuffer.isEmpty()) {
-            return;
+    private void periodFlush() {
+        if (!transactionBuffer.isEmpty()) {
+            flushBuffer();
         }
+    }
 
+    // 워커 종료 전 버퍼에 남은 데이터를 DB에 저장
+    private void forceFlushAll () {
+        log.info("[TradeWorker] 워커 종료 전 잔여 데이터 Flush 시작");
+        while (!transactionBuffer.isEmpty()) {
+            flushBuffer();
+        }
+        log.info("[TradeWorker] 모든 잔여 데이터 Flush 완료");
+    }
+
+    // 최대 1000건의 내역을 DB에 한 번에 저장
+    private void flushBuffer() {
         List<TransactionHistDTO> transactionToSave = new ArrayList<>();
         while (!transactionBuffer.isEmpty() && transactionToSave.size() < 1000) {
             // 버퍼에서 처리할 체결 내역 로그를 하나씩 꺼내옴 (최대 1000개)
-            transactionToSave.add(transactionBuffer.poll());
+            TransactionHistDTO data = transactionBuffer.poll();
+            if (data != null) transactionToSave.add(data);
         }
 
         if (!transactionToSave.isEmpty()) {
-            // 처리할 체결 내역들을 한 번에 처리
-            orderRepository.bulkInsertTransactionHists(transactionToSave);
-            log.info("[DB] {}건의 체결 내역 저장 완료", transactionToSave.size());
+            try {
+                // 처리할 체결 내역들을 한 번에 처리
+                orderRepository.bulkInsertTransactionHists(transactionToSave);
+                log.info("[TradeWorker] {}건의 체결 내역 DB에 저장 완료", transactionToSave.size());
+            } catch (Exception e) {
+                transactionBuffer.addAll(transactionToSave);
+                log.error("[TradeWorker] 체결 내역 저장 중 오류가 발생하여 데이터를 재삽입: ", e);
+            }
         }
     }
 

--- a/src/main/java/com/kanghwang/khholdings/global/util/RedisKeyManager.java
+++ b/src/main/java/com/kanghwang/khholdings/global/util/RedisKeyManager.java
@@ -67,8 +67,13 @@ public class RedisKeyManager {
         return getPrefix() + "candle:" + unit + "m:" + tokenId + ":" + timestamp;
     }
 
-    // 11. 취소 주문 정보
+    // 11. 취소 주문 정보 (STRING)
     public String getCancelKey(Long orderId) {
         return getPrefix() + "cancel:mark:" + orderId;
+    }
+
+    // 12. 사용자별 주문 정보 (HASH)
+    public String getPersonalOrderBookKey(Long walletId, OrderSide side) {
+        return getPrefix() + "orderbook:" + walletId + ":" + side.name().toLowerCase();
     }
 }

--- a/src/main/resources/mapper/OrderMapper.xml
+++ b/src/main/resources/mapper/OrderMapper.xml
@@ -91,6 +91,7 @@
             #{h.remainingPrice}, #{h.fee}, #{h.hashValue}, #{h.createdAt}
             )
         </foreach>
+        ON CONFLICT (transaction_id) DO NOTHING  -- 중복 방지
     </insert>
 
     <!-- 봉 데이터 벌크 인서트 -->


### PR DESCRIPTION
## 📌 작업 내용 요약 (Summary)
- 매수 매도 동시에 불가하도록 막기
- TradeWorker 종료 시 잔여 데이터 강제 flush
- 벌크 인서트에서 에러 발생 시 버퍼에 재삽입

## 📝 변경 사항 (Key Changes)
- [ ] OrderRedisService
- [ ] OrderService
- [ ] TradeWorker
- [ ] OrderMapper

## 📸 스크린샷 (Screenshots / Demos)
| Feature | Screenshot |
| :--- | :--- |
| 기능명 | 사진첨부 |

## 🔗 연관된 이슈 (Related Issues)
- Close #

## 🧐 주요 리뷰 포인트 (Review Point)
- 

## ✅ 최종 PR전 체크 리스트 (Checklist)
- [ ] 코딩 컨벤션(Checkstyle)을 준수하였는가?
- [ ] 불필요한 주석이나 시스템 로그(console.log, print)를 제거하였는가?
- [ ] 변경 사항에 대한 테스트를 완료하였는가?
- [ ] 관련 문서를 업데이트하였는가?
