### PR TITLE
[FIX] Redis 자산 정보 업데이트 시 타입 변환 에러 수정

### DIFF
--- a/src/main/java/com/kanghwang/khholdings/domain/my/MyService.java
+++ b/src/main/java/com/kanghwang/khholdings/domain/my/MyService.java
@@ -36,12 +36,12 @@ public class MyService {
 		// Redis에 자산 정보가 없는 경우 DB에서 조회한 값으로 초기화
 		if (data != null) {
 			String walletKey = redisKeyManager.getPersonalWalletInfoKey(walletId);
-			RMap<String, BigDecimal> walletMap = redissonClient.getMap(walletKey, StringCodec.INSTANCE);
+			RMap<String, Object> walletMap = redissonClient.getMap(walletKey, StringCodec.INSTANCE);
 
 			if (walletMap.isEmpty()) {
-				walletMap.put("cash_balance", data.getCashBalance());
-				walletMap.put("frozen_amount", data.getFrozenAmount());
-				walletMap.put("total_purchased_value", data.getTotalPurchasedValue());
+				walletMap.put("cash_balance", data.getCashBalance().toPlainString());
+				walletMap.put("frozen_amount", data.getFrozenAmount().toPlainString());
+				walletMap.put("total_purchased_value", data.getTotalPurchasedValue().toPlainString());
 
 				// 데이터가 들어온 시점에 TTL 설정 (1시간)
 				walletMap.expire(1, TimeUnit.HOURS);

--- a/src/main/java/com/kanghwang/khholdings/domain/order/bot/TradingSimulationBot.java
+++ b/src/main/java/com/kanghwang/khholdings/domain/order/bot/TradingSimulationBot.java
@@ -47,8 +47,7 @@ public class TradingSimulationBot {
 
 		try {
 //			OrderRequestDTO randomOrder = createRandomOrder();
-// 			createAggressiveOrder();
-			increasePriceStepByStep();
+			createAggressiveOrder();
 
 //			log.info(">>>> [BOT] 주문 생성 | 타입: {} | 사이드: {} | 가격: {} | 수량: {} | 총 주문액: {}",
 //				randomOrder.getOrderType(),
@@ -61,51 +60,6 @@ public class TradingSimulationBot {
 
 		} catch (Exception e) {
 			log.error(">>>> [BOT] 주문 처리 중 오류: ", e);
-		}
-	}
-
-	// 테스트: 45번 토큰 가격 100원씩 증가
-	private BigDecimal currentBotPrice = new BigDecimal("5000");
-	private final Long TARGET_TOKEN_ID = 45L;
-	private void increasePriceStepByStep() {
-		try {
-			// 1. 가격 상승 (5000원부터 시작해서 매 호출마다 100원씩 상승)
-			currentBotPrice = currentBotPrice.add(new BigDecimal("100"));
-
-			BigDecimal volume = new BigDecimal("10.0"); // 체결 수량 10개 고정
-			Long sellerId = 14L; // 메이커 (매도벽)
-			Long buyerId = 3L;  // 테이커 (매수)
-
-			// [STEP 1] 6번 지갑이 '지정가 매도' (벽 세우기)
-			OrderRequestDTO sellOrder = OrderRequestDTO.builder()
-				.walletId(sellerId)
-				.tokenId(TARGET_TOKEN_ID)
-				.orderSide(OrderSide.SELL)
-				.orderType(OrderType.LIMIT)
-				.orderPrice(currentBotPrice)
-				.orderVolume(volume)
-				.totalPrice(BigDecimal.ZERO)
-				.build();
-
-			orderService.placeOrder(sellOrder);
-
-			// [STEP 2] 7번 지갑이 '시장가 매수' (즉시 체결)
-			// 시장가 매수는 totalPrice에 지불할 최대 금액을 담음
-			OrderRequestDTO buyOrder = OrderRequestDTO.builder()
-				.walletId(buyerId)
-				.tokenId(TARGET_TOKEN_ID)
-				.orderSide(OrderSide.BUY)
-				.orderType(OrderType.MARKET)
-				.orderPrice(BigDecimal.ZERO)
-				.orderVolume(BigDecimal.ZERO)
-				.totalPrice(currentBotPrice.multiply(volume))
-				.build();
-
-			orderService.placeOrder(buyOrder);
-
-		} catch (Exception e) {
-			log.error(">>>> [BOT] 45번 토큰 가격 상승 루프 오류: {}", e.getMessage());
-			// 에러 발생 시 너무 낮게 떨어지지 않도록 현재가 유지 혹은 로그 확인
 		}
 	}
 

--- a/src/main/java/com/kanghwang/khholdings/domain/order/service/OrderRedisService.java
+++ b/src/main/java/com/kanghwang/khholdings/domain/order/service/OrderRedisService.java
@@ -349,9 +349,15 @@ public class OrderRedisService {
 			// 지정가 매수인데 주문 요청 금액보다 싸게 사서 돈이 남은 경우 추가 환불
 			if (myOrderDTO.getOrderType() == OrderType.LIMIT && myOrderDTO.getOrderSide() == OrderSide.BUY
 				&& myOrderDTO.getRemainingCash().compareTo(BigDecimal.ZERO) > 0) {
-
-				// Redis 동결 금액 즉시 해제
-				finalFrozen = releaseFrozenCash(myOrderDTO.getWalletId(), myOrderDTO.getRemainingCash());
+				// Redis 동결 금액 즉시 해제 (예수금과 총 매입금액은 변동 X)
+				WalletUpdateDTO result = safeUpdateWallet(
+					myOrderDTO.getWalletId(),
+					myOrderDTO.getTokenId(),
+					BigDecimal.ZERO,
+					myOrderDTO.getRemainingCash().negate(),
+					BigDecimal.ZERO
+				);
+				finalFrozen = result.getFrozenAmount();
 				needWalletUpdate = true;
 
 				// 비동기 정산 및 이력 저장용 Stream에 저장 후 DB 프로시저 호출
@@ -398,23 +404,33 @@ public class OrderRedisService {
 
 	// 동결 금액 해제
 	private BigDecimal releaseFrozenCash(Long walletId, BigDecimal amount) {
-		String walletKey = redisKeyManager.getPersonalWalletInfoKey(walletId);
-		RMap<String, BigDecimal> walletMap = redissonClient.getMap(walletKey, StringCodec.INSTANCE);
-		return walletMap.addAndGet("frozen_amount", amount.negate());
+		WalletUpdateDTO result = safeUpdateWallet(
+			walletId,
+			null,
+			BigDecimal.ZERO,
+			amount.negate(),
+			BigDecimal.ZERO
+		);
+
+		return result.getFrozenAmount();
 	}
 
 	// 지갑 정보 실시간 업데이트
 	private void publishWalletOnlyUpdate(Long walletId, Long tokenId, BigDecimal frozenAmount) {
 		String walletKey = redisKeyManager.getPersonalWalletInfoKey(walletId);
-		RMap<String, BigDecimal> walletMap = redissonClient.getMap(walletKey, StringCodec.INSTANCE);
+		RMap<String, Object> walletMap = redissonClient.getMap(walletKey, StringCodec.INSTANCE);
 		TokenShortDTO tokenInfo = marketService.selectTokenShortInfo(tokenId);
 
 		WalletUpdateDTO update = new WalletUpdateDTO(
-			walletId, tokenId, tokenInfo.getTokenName(), tokenInfo.getTickerSymbol(),
-			walletMap.get("cash_balance"),
+			walletId,
+			tokenId,
+			tokenInfo.getTokenName(),
+			tokenInfo.getTickerSymbol(),
+			getSafeBigDecimal(walletMap.get("cash_balance")),
 			frozenAmount,
-			walletMap.get("total_purchased_value"),
-			BigDecimal.ZERO, BigDecimal.ZERO // 수량은 필요에 따라 세팅
+			getSafeBigDecimal(walletMap.get("total_purchased_value")),
+			BigDecimal.ZERO,
+			BigDecimal.ZERO
 		);
 		redissonClient.getTopic("topic:wallet:" + walletId).publish(update);
 	}
@@ -532,22 +548,24 @@ public class OrderRedisService {
 		BigDecimal finalTotalPurchasedValue = BigDecimal.ZERO;
 
 		if (orderInfo.getOrderSide() == OrderSide.BUY) {
-			String walletKey = redisKeyManager.getPersonalWalletInfoKey(orderInfo.getWalletId());
-			RMap<String, BigDecimal> walletMap = redissonClient.getMap(walletKey, StringCodec.INSTANCE);
-
-			// 미체결된 잔액만큼 동결 해제 및 웹소켓 발행
-			finalFrozenAmount = walletMap.addAndGet("frozen_amount", orderInfo.getRemainingCash().negate());
-			finalCashBalance = walletMap.get("cash_balance");
-			finalTotalPurchasedValue = walletMap.get("total_purchased_value");
-
-			TokenShortDTO tokenInfo = marketService.selectTokenShortInfo(tokenId);
-
-			WalletUpdateDTO cancelUpdate = new WalletUpdateDTO(
-				orderInfo.getWalletId(), tokenId, tokenInfo.getTokenName(), tokenInfo.getTickerSymbol(),
-				finalFrozenAmount, finalCashBalance, finalTotalPurchasedValue,
-				orderInfo.getRemainingToken(), BigDecimal.ZERO
+			// 동결금액만 해제
+			WalletUpdateDTO walletResult = safeUpdateWallet(
+				orderInfo.getWalletId(),
+				tokenId,
+				BigDecimal.ZERO,
+				orderInfo.getRemainingCash().negate(),
+				BigDecimal.ZERO
 			);
-			redissonClient.getTopic("topic:wallet:" + orderInfo.getWalletId()).publish(cancelUpdate);
+
+			// 업데이트된 최신 자산 정보
+			finalFrozenAmount = walletResult.getFrozenAmount();               // 동결금액
+			finalCashBalance = walletResult.getCashBalance();                 // 예수금
+			finalTotalPurchasedValue = walletResult.getTotalPurchasedValue(); // 매입금액
+
+			// 웹소켓 발행
+			walletResult.setTokenQty(orderInfo.getRemainingToken());
+
+			redissonClient.getTopic("topic:wallet:" + orderInfo.getWalletId()).publish(walletResult);
 		}
 
 		// 2-3. 호가창, 상세 정보에서 제거
@@ -568,46 +586,92 @@ public class OrderRedisService {
 		log.info("[주문 취소 예약] OrderId {}", orderId);
 	}
 
-	// 사용자별 자산 업데이트
+	// 사용자별 자산 업데이트 (Redis)
 	private void updateWalletInfo(Long walletId, Long tokenId, BigDecimal price, BigDecimal volume, OrderSide side) {
-		// 1. 키 매니저를 통한 Redis Key 생성
-		String walletKey = redisKeyManager.getPersonalWalletInfoKey(walletId);
-		String holdingKey = redisKeyManager.getPersonalHoldingsInfoKey(walletId);
-		String marketPriceKey = redisKeyManager.getMarketPriceKey();
-
-		// 2. 현재 시장가 업데이트
-		redissonClient.getMap(marketPriceKey).put(String.valueOf(tokenId), price);
-
-		// 3. 자산 요약 정보 업데이트 (예수금, 총 매입금액)
-		RMap<String, BigDecimal> walletMap = redissonClient.getMap(walletKey, StringCodec.INSTANCE);
+		// 1. 체결량 계산
 		BigDecimal tradeAmount = price.multiply(volume);
 
-		// 예수금: 매수 -, 매도 cash +
-		BigDecimal finalCashBalance = walletMap.addAndGet("cash_balance",
-			(side == OrderSide.BUY) ? tradeAmount.negate() : tradeAmount);
-		BigDecimal finalTotalPurchasedValue = walletMap.addAndGet("total_purchased_value",
-			(side == OrderSide.BUY) ? tradeAmount : tradeAmount.negate());
+		// 2. 증분(Delta) 계산
+		BigDecimal cashDelta = (side == OrderSide.BUY) ? tradeAmount.negate() : tradeAmount;        // 예수금: 매수 -, 매도 +
+		BigDecimal frozenDelta = (side == OrderSide.BUY) ? tradeAmount.negate() : BigDecimal.ZERO;  // 동결금액: 매수 -
+		BigDecimal purchasedDelta = (side == OrderSide.BUY) ? tradeAmount : tradeAmount.negate();   // 매입금액: 매수 +, 매도 -
 
-		// 총 매입금액: 매수 +, 매도 -
+		// 3. 자산 정보 업데이트
+		WalletUpdateDTO walletResult = safeUpdateWallet(walletId, tokenId, cashDelta, frozenDelta, purchasedDelta);
 
-		// 동결금액: 매수 -
-		BigDecimal finalFrozenAmount = BigDecimal.ZERO;
-		if (side == OrderSide.BUY) {
-			finalFrozenAmount = walletMap.addAndGet("frozen_amount", tradeAmount.negate());
-		}
-
-		// 4. 보유 토큰 상세 업데이트
+		// 4. 보유 토큰 업데이트
 		TokenShortDTO tokenInfo = marketService.selectTokenShortInfo(tokenId);
+		String holdingKey = redisKeyManager.getPersonalHoldingsInfoKey(walletId);
 		HoldingShortDTO holdingInfo = updateHoldingDetail(holdingKey, tokenId, price, volume, side, tokenInfo);
 
 		// 5. 실시간 토픽 발행 (Pub/Sub)
-		WalletUpdateDTO newWalletInfo = new WalletUpdateDTO(
-			walletId, tokenId, tokenInfo.getTokenName(), tokenInfo.getTickerSymbol(),
-			finalFrozenAmount, finalCashBalance, finalTotalPurchasedValue,
-			holdingInfo.getQuantity(), holdingInfo.getPurchasedValue()
-		);
+		walletResult.setTokenQty(holdingInfo.getQuantity());
+		walletResult.setTotalPurchasedValue(holdingInfo.getPurchasedValue());
 
-		redissonClient.getTopic("topic:wallet:" + walletId).publish(newWalletInfo);
+		redissonClient.getTopic("topic:wallet:" + walletId).publish(walletResult);
+	}
+
+	// 자산 정보 업데이트 (분산 락)
+	private WalletUpdateDTO safeUpdateWallet(Long walletId, Long tokenId, BigDecimal cashDelta, BigDecimal frozenDelta, BigDecimal purchasedDelta) {
+		String lockKey = redisKeyManager.getWalletLockKey(walletId);
+		RLock lock = redissonClient.getLock(lockKey);
+		String walletKey = redisKeyManager.getPersonalWalletInfoKey(walletId);
+
+		try {
+			// 5초 대기, Watchdog 활성화(-1)
+			if (lock.tryLock(5, -1, TimeUnit.SECONDS)) {
+				try {
+					// StringCodec을 사용하여 문자열로 읽고 Object로 받아 타입 유연성 확보
+					RMap<String, Object> walletMap = redissonClient.getMap(walletKey, StringCodec.INSTANCE);
+
+					// 값 추출하여 BigDecimal로 변환
+					BigDecimal currentCash = getSafeBigDecimal(walletMap.get("cash_balance"));
+					BigDecimal currentFrozen = getSafeBigDecimal(walletMap.get("frozen_amount"));
+					BigDecimal currentPurchased = getSafeBigDecimal(walletMap.get("total_purchased_value"));
+
+					// 연산
+					BigDecimal finalCash = currentCash.add(cashDelta);
+					BigDecimal finalFrozen = currentFrozen.add(frozenDelta);
+					BigDecimal finalPurchased = currentPurchased.add(purchasedDelta);
+
+					// 저장
+					walletMap.put("cash_balance", finalCash.toPlainString());
+					walletMap.put("frozen_amount", finalFrozen.toPlainString());
+					walletMap.put("total_purchased_value", finalPurchased.toPlainString());
+
+					String tokenName = "";
+					String ticker = "";
+					if (tokenId != null) {
+						TokenShortDTO tokenInfo = marketService.selectTokenShortInfo(tokenId);
+						tokenName = tokenInfo.getTokenName();
+						ticker = tokenInfo.getTickerSymbol();
+					}
+
+					return new WalletUpdateDTO(
+						walletId,
+						tokenId,
+						tokenName,
+						ticker,
+						finalFrozen,
+						finalCash,
+						finalPurchased,
+						BigDecimal.ZERO,
+						BigDecimal.ZERO
+					);
+				} finally {
+					if (lock.isHeldByCurrentThread()) lock.unlock();
+				}
+			}
+		} catch (InterruptedException e) {
+			Thread.currentThread().interrupt();
+		}
+		throw new RuntimeException("지갑 업데이트 락 획득 실패: " + walletId);
+	}
+
+	// 타입을 BigDecimal로 변환
+	private BigDecimal getSafeBigDecimal(Object value) {
+		if (value == null) return BigDecimal.ZERO;
+		return new BigDecimal(String.valueOf(value));
 	}
 
 	// 사용자별 보유 토큰 업데이트

--- a/src/main/java/com/kanghwang/khholdings/domain/order/service/OrderService.java
+++ b/src/main/java/com/kanghwang/khholdings/domain/order/service/OrderService.java
@@ -1,7 +1,9 @@
 package com.kanghwang.khholdings.domain.order.service;
 
 import java.math.BigDecimal;
+import java.util.concurrent.TimeUnit;
 
+import org.redisson.api.RLock;
 import org.redisson.api.RMap;
 import org.redisson.api.RedissonClient;
 import org.redisson.client.codec.StringCodec;
@@ -100,13 +102,10 @@ public class OrderService {
 		insertOutbox(orderDTO, "ORDER"); // PENDING
 
 		// 5. Redis 지갑 정보에 동결 금액 추가
-		String walletKey = redisKeyManager.getPersonalWalletInfoKey(orderDTO.getWalletId());
-		RMap<String, BigDecimal> walletMap = redissonClient.getMap(walletKey, StringCodec.INSTANCE);
-
 		if (orderDTO.getOrderSide() == OrderSide.BUY) {
 			// 매수: (주문가 * 수량) 만큼 현금 동결
 			BigDecimal freezeAmount = orderDTO.getOrderPrice().multiply(orderDTO.getOrderVolume());
-			walletMap.addAndGet("frozen_amount", freezeAmount);
+			freezeCash(orderDTO.getWalletId(), freezeAmount);
 		}
 
 		// 6. DB에서 주문 생성 후, Redis 매칭 엔진에 추가
@@ -229,5 +228,40 @@ public class OrderService {
 	@Transactional(propagation = Propagation.REQUIRES_NEW)
 	public void updateOutboxStatus(Long orderId, String type, String status, int retryCount) {
 		outboxRepository.updateOutboxStatus(orderId, type, status, retryCount);
+	}
+
+	// 매수 시 자산 동결 (분산 락)
+	public BigDecimal freezeCash(Long walletId, BigDecimal amount) {
+		String lockKey = redisKeyManager.getWalletLockKey(walletId);
+		RLock lock = redissonClient.getLock(lockKey);
+
+		try {
+			// 5초 대기 / 처리 지연 시 점유 시간 연장 (미처리 또는 오처리 방지)
+			if (lock.tryLock(5, -1, TimeUnit.SECONDS)) {
+				try {
+					String walletKey = redisKeyManager.getPersonalWalletInfoKey(walletId);
+					RMap<String, Object> walletMap = redissonClient.getMap(walletKey, StringCodec.INSTANCE);
+
+					// 현재 동결 금액 가져오기 (타입 변환)
+					Object rawFrozen = walletMap.get("frozen_amount");
+					BigDecimal currentFrozen = (rawFrozen != null)
+						? new BigDecimal(String.valueOf(rawFrozen))
+						: BigDecimal.ZERO;
+
+					// 동결 금액 가산
+					BigDecimal updatedFrozen = currentFrozen.add(amount);
+					walletMap.put("frozen_amount", updatedFrozen.toPlainString());
+
+					log.info("[현금 동결] Wallet: {}, Amount: {}, Total: {}", walletId, amount, updatedFrozen);
+					return updatedFrozen;
+				} finally {
+					if (lock.isHeldByCurrentThread()) lock.unlock();
+				}
+			}
+			throw new RuntimeException("[현금 동결 실패] 시스템 지연");
+		} catch (InterruptedException e) {
+			Thread.currentThread().interrupt();
+			throw new RuntimeException("[현금 동결 중 인터럽트 발생]", e);
+		}
 	}
 }

--- a/src/main/java/com/kanghwang/khholdings/global/util/RedisKeyManager.java
+++ b/src/main/java/com/kanghwang/khholdings/global/util/RedisKeyManager.java
@@ -94,12 +94,17 @@ public class RedisKeyManager {
         return getPrefix() + "topic:wallet:*";
     }
 
-    // 16. 시장가 (HASH)
+    // 16. 사용자별 자산 분산락 (RLOCK): 자산 정보 업데이트 시 점유용
+    public String getWalletLockKey(Long walletId) {
+        return getPrefix() + "lock:wallet:" + walletId;
+    }
+
+    // 17. 시장가 (HASH)
     public String getMarketPriceKey() {
         return getPrefix() + "market:price";
     }
 
-    // 17. 시장가 (TOPIC): 시장가 실시간 전파용
+    // 18. 시장가 (TOPIC): 시장가 실시간 전파용
     public String getMarketPriceTopicKey() {
         return getPrefix() + "topic:market:price";
     }

--- a/src/main/resources/mapper/MyMapper.xml
+++ b/src/main/resources/mapper/MyMapper.xml
@@ -214,6 +214,9 @@
            5000000,
            'kh 증권'
        )
+        ON CONFLICT (wallet_id)
+        DO UPDATE SET
+            user_id = EXCLUDED.user_id
     </insert>
 
     <select id="selectAccount" parameterType="long" resultType="long">


### PR DESCRIPTION
## 📌 작업 내용 요약 (Summary)
- 연동하려는 지갑이 다른 사람 거일 때 뺏어오기 (UPSERT)
- StringCodec으로 인한 타입 변환 에러 해결
- 봇 원복

## 📝 변경 사항 (Key Changes)
- [ ] 마리팜에서 계좌 연동하며 지갑 생성할 때, 이미 다른 사용자와 연결되어 있다면 user_id 변경 (insert 시 duplicate key 방지용)
- [ ] String으로 가져온 값을 BigDecimal로 안전하게 변환

## 📸 스크린샷 (Screenshots / Demos)
| Feature | Screenshot |
| :--- | :--- |
| 기능명 | 사진첨부 |

## 🔗 연관된 이슈 (Related Issues)
- Close #

## 🧐 주요 리뷰 포인트 (Review Point)
- 

## ✅ 최종 PR전 체크 리스트 (Checklist)
- [ ] 코딩 컨벤션(Checkstyle)을 준수하였는가?
- [ ] 불필요한 주석이나 시스템 로그(console.log, print)를 제거하였는가?
- [ ] 변경 사항에 대한 테스트를 완료하였는가?
- [ ] 관련 문서를 업데이트하였는가?
