### PR TITLE
[FIX] Redis 지갑 정보 업데이트 할 때 수수료 반영

### DIFF
--- a/src/main/java/com/kanghwang/khholdings/domain/market/service/MarketService.java
+++ b/src/main/java/com/kanghwang/khholdings/domain/market/service/MarketService.java
@@ -98,18 +98,18 @@ public class MarketService {
     public List<CandleDTO> selectCandles(Long tokenId, int unit, long start, long end) {
 
         long start3 = System.currentTimeMillis();
-        log.info("차트 조회 [1] - 시작");
+        // log.info("차트 조회 [1] - 시작");
 
         String cacheKey = String.format("candle:%s:%d", unit + "m", tokenId); // Redis 캐시 키
         long currentMinute = OffsetDateTime.now().truncatedTo(ChronoUnit.MINUTES).toEpochSecond();
         String liveCandleKey = redisKeyManager.getCandleKey(tokenId, unit, currentMinute); // Redis 실시간 키
 
         long redisStart = System.currentTimeMillis();
-        log.info("차트 조회 - redis 조회");
+        // log.info("차트 조회 - redis 조회");
         // 1. Redis 캐시 조회
         RScoredSortedSet<CandleDTO> zset = redissonClient.getScoredSortedSet(cacheKey);
         List<CandleDTO> resultList = new ArrayList<>(zset.valueRange(start, true, end, true));
-        log.info("차트 조회 redis 조회 - 로직 완료까지 걸린 시간: {}ms", (System.currentTimeMillis() - start3));
+        // log.info("차트 조회 redis 조회 - 로직 완료까지 걸린 시간: {}ms", (System.currentTimeMillis() - start3));
 
         // 2. 캐시된 데이터에 없는 범위
         boolean isMissing = false;
@@ -151,7 +151,7 @@ public class MarketService {
             }
         }
 
-        log.info("차트 조회 [1] 로직 완료까지 걸린 시간: {}ms", (System.currentTimeMillis() - start3));
+        // log.info("차트 조회 [1] 로직 완료까지 걸린 시간: {}ms", (System.currentTimeMillis() - start3));
         return resultList;
     }
 
@@ -160,7 +160,7 @@ public class MarketService {
             RScoredSortedSet<CandleDTO> zset) {
 
         long start2 = System.currentTimeMillis();
-        log.info("차트 조회 [2]");
+        // log.info("차트 조회 [2]");
 
         RLock lock = redissonClient.getLock("lock:candles:" + tokenId);
         try {
@@ -202,7 +202,7 @@ public class MarketService {
             }
         }
 
-        log.info("차트 조회 [2] 로직 완료까지 걸린 시간: {}ms", (System.currentTimeMillis() - start2));
+        // log.info("차트 조회 [2] 로직 완료까지 걸린 시간: {}ms", (System.currentTimeMillis() - start2));
 
         return new ArrayList<>();
     }

--- a/src/main/java/com/kanghwang/khholdings/domain/my/MyService.java
+++ b/src/main/java/com/kanghwang/khholdings/domain/my/MyService.java
@@ -39,23 +39,18 @@ public class MyService {
 		Long start = System.currentTimeMillis();
 		WalletDTO data =  myRepository.selectWalletById(walletId);
 
-		// Redis에 자산 정보가 없는 경우 DB에서 조회한 값으로 초기화
+		// DB 조회 시마다 Redis 자산 정보 덮어쓰기
 		if (data != null) {
 			String walletKey = redisKeyManager.getPersonalWalletInfoKey(walletId);
 			RMap<String, Object> walletMap = redissonClient.getMap(walletKey, StringCodec.INSTANCE);
 
-			if (walletMap.isEmpty()) {
-				Map<String, Object> initData = new HashMap<>();
-				initData.put("cash_balance", data.getCashBalance().toPlainString());
-				initData.put("frozen_amount", data.getFrozenAmount().toPlainString());
-				initData.put("total_purchased_value", data.getTotalPurchasedValue().toPlainString());
+			Map<String, Object> initData = new HashMap<>();
+			initData.put("cash_balance", data.getCashBalance().toPlainString());
+			initData.put("frozen_amount", data.getFrozenAmount().toPlainString());
+			initData.put("total_purchased_value", data.getTotalPurchasedValue().toPlainString());
 
-				walletMap.putAll(initData);                    // 한 번에 처리
-				walletMap.expire(1, TimeUnit.HOURS); // 데이터가 들어온 시점에 TTL 설정 (1시간)
-			}
-
-			// Redis에 데이터가 있다면 TTL 연장 (1시간)
-			walletMap.expire(1, TimeUnit.HOURS);
+			walletMap.putAll(initData); // 한 번에 처리
+			walletMap.expire(1, TimeUnit.HOURS); // TTL 연장 (1시간)
 		}
 
 		long end = System.currentTimeMillis();

--- a/src/main/java/com/kanghwang/khholdings/domain/my/MyService.java
+++ b/src/main/java/com/kanghwang/khholdings/domain/my/MyService.java
@@ -1,7 +1,9 @@
 package com.kanghwang.khholdings.domain.my;
 
 import java.math.BigDecimal;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.concurrent.TimeUnit;
 
 import org.redisson.api.RMap;
@@ -19,7 +21,9 @@ import com.kanghwang.khholdings.domain.order.dto.HoldingShortDTO;
 import com.kanghwang.khholdings.global.util.RedisKeyManager;
 
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 
+@Slf4j
 @RequiredArgsConstructor
 @Service
 public class MyService {
@@ -31,6 +35,7 @@ public class MyService {
 
 	// 특정 계좌 및 지갑 조회
 	public WalletDTO selectWalletById(Long walletId){
+		Long start = System.currentTimeMillis();
 		WalletDTO data =  myRepository.selectWalletById(walletId);
 
 		// Redis에 자산 정보가 없는 경우 DB에서 조회한 값으로 초기화
@@ -39,17 +44,21 @@ public class MyService {
 			RMap<String, Object> walletMap = redissonClient.getMap(walletKey, StringCodec.INSTANCE);
 
 			if (walletMap.isEmpty()) {
-				walletMap.put("cash_balance", data.getCashBalance().toPlainString());
-				walletMap.put("frozen_amount", data.getFrozenAmount().toPlainString());
-				walletMap.put("total_purchased_value", data.getTotalPurchasedValue().toPlainString());
+				Map<String, Object> initData = new HashMap<>();
+				initData.put("cash_balance", data.getCashBalance().toPlainString());
+				initData.put("frozen_amount", data.getFrozenAmount().toPlainString());
+				initData.put("total_purchased_value", data.getTotalPurchasedValue().toPlainString());
 
-				// 데이터가 들어온 시점에 TTL 설정 (1시간)
-				walletMap.expire(1, TimeUnit.HOURS);
+				walletMap.putAll(initData);                    // 한 번에 처리
+				walletMap.expire(1, TimeUnit.HOURS); // 데이터가 들어온 시점에 TTL 설정 (1시간)
 			}
 
 			// Redis에 데이터가 있다면 TTL 연장 (1시간)
 			walletMap.expire(1, TimeUnit.HOURS);
 		}
+
+		long end = System.currentTimeMillis();
+		// log.info("자산 조회까지 걸린 시간: {}ms", end - start);
 
 		return data;
 	}
@@ -57,6 +66,7 @@ public class MyService {
 	// 보유 토큰 조회
 	public List<HoldingDTO> selectTokenByWalletId(Long walletId, Integer page){
 		// 1. DB에서 리스트 조회
+		long start = System.currentTimeMillis();
 		List<HoldingDTO> list =  myRepository.selectTokenByWalletId(walletId, page); // 'page = 0'으로 전체 조회
 
 		if (list == null || list.isEmpty()) {
@@ -74,6 +84,8 @@ public class MyService {
 		RMap<String, String> holdingMap = redissonClient.getMap(holdingKey, StringCodec.INSTANCE);
 
 		if (holdingMap.isEmpty()&& !filteredList.isEmpty()) {
+			Map<String, String> batchData = new HashMap<>();
+
 			for (HoldingDTO h : filteredList) {
 				HoldingShortDTO dto = new HoldingShortDTO(
 					h.getTokenName(),
@@ -82,17 +94,20 @@ public class MyService {
 					h.getPurchasedValue()
 				);
 				try {
-					holdingMap.put(String.valueOf(h.getTokenId()), objectMapper.writeValueAsString(dto));
+					batchData.put(String.valueOf(h.getTokenId()), objectMapper.writeValueAsString(dto));
 				} catch (JsonProcessingException e) {
-					// log.error("초기 데이터 로딩 중 직렬화 실패", e);
+					log.error("초기 데이터 로딩 중 직렬화 실패", e);
 				}
 			}
 
-			// 데이터가 들어온 시점에 TTL 설정 (1시간)
-			holdingMap.expire(1, TimeUnit.HOURS);
+			holdingMap.putAll(batchData);                   // 한 번에 모든 데이터 저장
+			holdingMap.expire(1, TimeUnit.HOURS); // 데이터가 들어온 시점에 TTL 설정 (1시간)
 		} else if (!holdingMap.isEmpty()) {
 			holdingMap.expire(1, TimeUnit.HOURS);
 		}
+
+		long end = System.currentTimeMillis();
+		// log.info("보유 토큰 조회까지 걸린 시간: {}ms", end - start);
 
 		return filteredList;
 	}

--- a/src/main/java/com/kanghwang/khholdings/domain/my/MyService.java
+++ b/src/main/java/com/kanghwang/khholdings/domain/my/MyService.java
@@ -1,6 +1,7 @@
 package com.kanghwang.khholdings.domain.my;
 
 import java.math.BigDecimal;
+import java.math.RoundingMode;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -65,7 +66,7 @@ public class MyService {
 
 	// 보유 토큰 조회
 	public List<HoldingDTO> selectTokenByWalletId(Long walletId, Integer page){
-		// 1. DB에서 리스트 조회
+		// 1. DB에서 보유 토큰 기본 정보 조회
 		long start = System.currentTimeMillis();
 		List<HoldingDTO> list =  myRepository.selectTokenByWalletId(walletId, page); // 'page = 0'으로 전체 조회
 
@@ -78,21 +79,41 @@ public class MyService {
 			.filter(h -> h.getTokenBalance() != null && h.getTokenBalance().compareTo(BigDecimal.ZERO) > 0)
 			.toList();
 
-		// 3. Redis 초기화 로직 (필터링된 데이터를 기준으로 작업)
-		// Redis에 보유 토큰 정보가 없는 경우 DB에서 조회한 값으로 초기화
+		// 3. Redis에서 모든 토큰의 현재가를 한 번에 가져옴
+		RMap<String, String> priceMap = redissonClient.getMap(redisKeyManager.getMarketPriceKey(), StringCodec.INSTANCE);
+		Map<String, String> currentPrices = priceMap.readAllMap();
+
+		// 4. 현재가를 기준으로 계산 및 Redis 초기화
 		String holdingKey = redisKeyManager.getPersonalHoldingsInfoKey(walletId);
 		RMap<String, String> holdingMap = redissonClient.getMap(holdingKey, StringCodec.INSTANCE);
 
-		if (holdingMap.isEmpty()&& !filteredList.isEmpty()) {
+		if (!filteredList.isEmpty()) {
 			Map<String, String> batchData = new HashMap<>();
 
 			for (HoldingDTO h : filteredList) {
+				// 현재가
+				String priceStr = currentPrices.get(String.valueOf(h.getTokenId()));
+				BigDecimal currentPrice = (priceStr != null) ? new BigDecimal(priceStr) : BigDecimal.ZERO;
+
+				// 계산
+				BigDecimal marketValue = h.getTokenBalance().multiply(currentPrice);
+				BigDecimal profitLoss = marketValue.subtract(h.getPurchasedValue());
+				BigDecimal profitLossRate = h.getPurchasedValue().compareTo(BigDecimal.ZERO) > 0
+					? profitLoss.divide(h.getPurchasedValue(), 4, RoundingMode.HALF_UP).multiply(new BigDecimal("100"))
+					: BigDecimal.ZERO;
+
+				// DTO 업데이트
+				h.setMarketValue(marketValue);
+				h.setProfitLoss(profitLoss);
+				h.setProfitLossRate(profitLossRate);
 				HoldingShortDTO dto = new HoldingShortDTO(
 					h.getTokenName(),
 					h.getTickerSymbol(),
 					h.getTokenBalance(),
 					h.getPurchasedValue()
 				);
+
+				// batch에 저장 (추후 Redis에 한꺼번에 저장)
 				try {
 					batchData.put(String.valueOf(h.getTokenId()), objectMapper.writeValueAsString(dto));
 				} catch (JsonProcessingException e) {
@@ -100,7 +121,7 @@ public class MyService {
 				}
 			}
 
-			holdingMap.putAll(batchData);                   // 한 번에 모든 데이터 저장
+			holdingMap.putAll(batchData); // 한 번에 모든 데이터 저장
 			holdingMap.expire(1, TimeUnit.HOURS); // 데이터가 들어온 시점에 TTL 설정 (1시간)
 		} else if (!holdingMap.isEmpty()) {
 			holdingMap.expire(1, TimeUnit.HOURS);

--- a/src/main/java/com/kanghwang/khholdings/domain/my/dto/HoldingDTO.java
+++ b/src/main/java/com/kanghwang/khholdings/domain/my/dto/HoldingDTO.java
@@ -19,6 +19,7 @@ public class HoldingDTO {
 	private String tickerSymbol;			// 종목 코드
 	private BigDecimal tokenBalance;		// 보유 수량
 	private BigDecimal purchasedValue;		// 매입 금액
+
 	private BigDecimal marketValue;			// 평가 금액
 	private BigDecimal profitLoss;			// 평가 손익
 	private BigDecimal profitLossRate;		// 수익률

--- a/src/main/java/com/kanghwang/khholdings/domain/order/service/OrderRedisService.java
+++ b/src/main/java/com/kanghwang/khholdings/domain/order/service/OrderRedisService.java
@@ -274,8 +274,10 @@ public class OrderRedisService {
 			redissonClient.getTopic(redisKeyManager.getMarketPriceTopicKey()).publish(liveMarketPrice);
 
 			// (6) 매수자/매도자 각각의 자산 및 보유 토큰 정보 업데이트
-			updateWalletInfo(buyWalletId, tokenId, targetPrice, executedVolume, OrderSide.BUY);
-			updateWalletInfo(sellWalletId, tokenId, targetPrice, executedVolume, OrderSide.SELL);
+			// 매수자: 체결된 만큼 동결 해제, 예수금 변동 없음, 매입금액 증가
+			updateWalletInfo(buyWalletId, tokenId, targetPrice, executedVolume, executedAmount, OrderSide.BUY);
+			// 매도자: 동결 해제 없음, 예수금 증가(수수료 제외), 매입금액 감소
+			updateWalletInfo(sellWalletId, tokenId, targetPrice, executedVolume, BigDecimal.ZERO, OrderSide.SELL);
 
 			log.info("[체결] Price {}, Volume {}, Amount {}", targetPrice.toPlainString(), executedVolume.toPlainString(), executedAmount.toPlainString());
 			log.info("[정산 예약] TradeID {}", tradeId);
@@ -415,7 +417,7 @@ public class OrderRedisService {
 		return result.getFrozenAmount();
 	}
 
-	// 지갑 정보 실시간 업데이트
+	// 지갑 정보 웹소켓 발행
 	private void publishWalletOnlyUpdate(Long walletId, Long tokenId, BigDecimal frozenAmount) {
 		String walletKey = redisKeyManager.getPersonalWalletInfoKey(walletId);
 		RMap<String, Object> walletMap = redissonClient.getMap(walletKey, StringCodec.INSTANCE);
@@ -586,25 +588,41 @@ public class OrderRedisService {
 		log.info("[주문 취소 예약] OrderId {}", orderId);
 	}
 
-	// 사용자별 자산 업데이트 (Redis)
-	private void updateWalletInfo(Long walletId, Long tokenId, BigDecimal price, BigDecimal volume, OrderSide side) {
-		// 1. 체결량 계산
-		BigDecimal tradeAmount = price.multiply(volume);
+	// 전자 지갑 업데이트 (Redis)
+	private void updateWalletInfo(Long walletId, Long tokenId, BigDecimal price, BigDecimal volume, BigDecimal executedAmount, OrderSide side) {
+		// 1. 증분(Delta) 계산
+		BigDecimal cashDelta = BigDecimal.ZERO;
+		BigDecimal frozenDelta = BigDecimal.ZERO;
+		BigDecimal purchasedDelta = BigDecimal.ZERO;
 
-		// 2. 증분(Delta) 계산
-		BigDecimal cashDelta = (side == OrderSide.BUY) ? tradeAmount.negate() : tradeAmount;        // 예수금: 매수 -, 매도 +
-		BigDecimal frozenDelta = (side == OrderSide.BUY) ? tradeAmount.negate() : BigDecimal.ZERO;  // 동결금액: 매수 -
-		BigDecimal purchasedDelta = (side == OrderSide.BUY) ? tradeAmount : tradeAmount.negate();   // 매입금액: 매수 +, 매도 -
+		if (side == OrderSide.BUY) {
+			// [매수자]
+			cashDelta = BigDecimal.ZERO;             // 예수금 : 변동 없음
+			frozenDelta = executedAmount.negate();   // 동결금액: 체결된 금액만큼 해제 (-)
+			purchasedDelta = executedAmount;         // 매입금액: 체결된 금액만큼 증가 (+)
+		} else {
+			// [매도자]
+			BigDecimal sellFee = executedAmount.multiply(F_RATE);
+			cashDelta = executedAmount.subtract(sellFee);   // 예수금: 체결 금액에서 수수료 제외하고 증가 (+)
+			frozenDelta = BigDecimal.ZERO;                  // 동결금액: 매도는 현금 동결 없음
+			purchasedDelta = executedAmount.negate();       // 매입금액: 체결된 금액만큼 감소 (-)
+		}
 
-		// 3. 자산 정보 업데이트
+		// 2. 자산 정보 업데이트
 		WalletUpdateDTO walletResult = safeUpdateWallet(walletId, tokenId, cashDelta, frozenDelta, purchasedDelta);
 
-		// 4. 보유 토큰 업데이트
+		// 3. 보유 토큰 업데이트
 		TokenShortDTO tokenInfo = marketService.selectTokenShortInfo(tokenId);
 		String holdingKey = redisKeyManager.getPersonalHoldingsInfoKey(walletId);
-		HoldingShortDTO holdingInfo = updateHoldingDetail(holdingKey, tokenId, price, volume, side, tokenInfo);
 
-		// 5. 실시간 토픽 발행 (Pub/Sub)
+		BigDecimal actualVolume = volume;
+		if (side == OrderSide.BUY) {
+			BigDecimal buyFeeToken = volume.multiply(F_RATE);
+			actualVolume = volume.subtract(buyFeeToken);  // 매수자는 수수료를 제외
+		}
+		HoldingShortDTO holdingInfo = updateHoldingDetail(holdingKey, tokenId, price, actualVolume, side, tokenInfo);
+
+		// 4. 실시간 토픽 발행 (Pub/Sub)
 		walletResult.setTokenQty(holdingInfo.getQuantity());
 		walletResult.setTotalPurchasedValue(holdingInfo.getPurchasedValue());
 
@@ -630,8 +648,8 @@ public class OrderRedisService {
 					BigDecimal currentPurchased = getSafeBigDecimal(walletMap.get("total_purchased_value"));
 
 					// 연산
-					BigDecimal finalCash = currentCash.add(cashDelta);
-					BigDecimal finalFrozen = currentFrozen.add(frozenDelta);
+					BigDecimal finalCash = currentCash.add(cashDelta).setScale(4, RoundingMode.HALF_UP);
+					BigDecimal finalFrozen = currentFrozen.add(frozenDelta).setScale(4, RoundingMode.HALF_UP);
 					BigDecimal finalPurchased = currentPurchased.add(purchasedDelta);
 
 					// 저장

--- a/src/main/resources/mapper/MyMapper.xml
+++ b/src/main/resources/mapper/MyMapper.xml
@@ -49,35 +49,17 @@
     </select>
 
     <select id="selectTokenByWalletId" parameterType="map" resultType="HoldingDTO">
-        WITH latest_token_quotes AS (
-            SELECT DISTINCT ON (token_id)
-            token_id,
-            closing_price
-        FROM token_quotes
-        WHERE unit = 1
-        ORDER BY token_id, candle_time DESC
-            )
         SELECT
             t.token_id             AS tokenId,
             t.token_name           AS tokenName,
             t.ticker_symbol        AS tickerSymbol,
             h.token_balance        AS tokenBalance,
-            h.purchased_value      AS purchasedValue,
-            (h.token_balance * ltq.closing_price) AS marketValue,
-            (h.token_balance * ltq.closing_price) - h.purchased_value AS profitLoss,
-            CASE
-                WHEN h.purchased_value = 0 THEN 0
-                ELSE
-                    ((h.token_balance * ltq.closing_price) - h.purchased_value)
-                        / h.purchased_value * 100
-                END AS profitLossRate
+            h.purchased_value      AS purchasedValue
         FROM holdings h
-                 JOIN tokens t
-                      ON h.token_id = t.token_id
-                 LEFT JOIN latest_token_quotes ltq
-                           ON h.token_id = ltq.token_id
+             JOIN tokens t
+                  ON h.token_id = t.token_id
         WHERE h.wallet_id = #{walletId}
-        AND t.deleted_at IS null
+            AND t.deleted_at IS null
         ORDER BY t.token_name
 
         <if test="page != null and page > 0">


### PR DESCRIPTION
## 📌 작업 내용 요약 (Summary)
- Redis 지갑 정보 업데이트 할 때 수수료 반영
- DB와 동일하게 지갑 정보 소수점 이하 4자리까지만 저장
- 전자지갑 조회 시마다 redis를 db 값으로 덮어쓰기
- 보유 토큰 조회 속도 개선
- 불필요한 로그 출력문 제거

## 📝 변경 사항 (Key Changes)
- [ ] 수수료 계산 로직 추가
- [ ] 전자지갑 조회 시마다 redis를 db 값으로 덮어쓰기 (정합성)
- [ ] 반복문 돌며 put 하던 거를 map에 담아두었다가 putall
- [ ] 시장가를 token_quotes 대신 redis에서 가져와서 계산
- [ ] redis 지갑 금액 소수점 이하 4자리까지만 (반올림)

## 📸 스크린샷 (Screenshots / Demos)
| Feature | Screenshot |
| :--- | :--- |
| 기능명 | 사진첨부 |

## 🔗 연관된 이슈 (Related Issues)
- Close #

## 🧐 주요 리뷰 포인트 (Review Point)
- 

## ✅ 최종 PR전 체크 리스트 (Checklist)
- [ ] 코딩 컨벤션(Checkstyle)을 준수하였는가?
- [ ] 불필요한 주석이나 시스템 로그(console.log, print)를 제거하였는가?
- [ ] 변경 사항에 대한 테스트를 완료하였는가?
- [ ] 관련 문서를 업데이트하였는가?
